### PR TITLE
Use existing pane if one is found

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -131,12 +131,12 @@ Set the default position of the runner pane.
 let VimuxOrientation = "h"
 ```
 
-### VimuxUseExistingPane
-Use exising pane (not used by vim) if found instead of running
+### VimuxUseNearestPane
+Use nearest pane (not used by vim) if found instead of running
 split-window.
 Useful if you always have two panes opened and you want Vimux to use the
 existing one.
 
 ```viml
-let VimuxUseExistingPane = 1
+let VimuxUseNearestPane = 1
 ```

--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -52,10 +52,10 @@ Options:
 Default: "v"
 
 ------------------------------------------------------------------------------
-2.3 g:VimuxUseExistingPane              *VimuxConfiguration_use_existing_pane*
+2.3 g:VimuxUseNearestPane                *VimuxConfiguration_use_nearest_pane*
 
 Use exising pane (not used by vim) if found instead of running split-window.
 
-  let VimuxUseExistingPane = 1
+  let VimuxUseNearestPane = 1
 
 Default: 0

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -130,9 +130,9 @@ class TmuxSession
   def runner_pane
     if @runner_pane.nil?
       type = Vim.evaluate('exists("g:_VimTmuxInspecting")') != 0
-      use_existing_pane = Vim.evaluate('exists("g:VimuxUseExistingPane")') != 0
-      if use_existing_pane && existing_inactive_pane_id
-        _run("select-pane -t #{target(:pane => existing_inactive_pane_id)}")
+      use_nearest_pane = Vim.evaluate('exists("g:VimuxUseNearestPane")') != 0
+      if use_nearest_pane && nearest_inactive_pane_id
+        _run("select-pane -t #{target(:pane => nearest_inactive_pane_id)}")
       else
         _run("split-window -p #{height} #{orientation}")
       end
@@ -167,7 +167,7 @@ class TmuxSession
     end
   end
 
-  def existing_inactive_pane_id
+  def nearest_inactive_pane_id
     panes = _run("list-pane").split("\n")
     pane = panes.find { |p| p !~ /active/ }
     pane ? pane.split(':').first : nil


### PR DESCRIPTION
I always have an existing pane below vim, and I'd like vimux to use that instead.

This is optional, and default to false. Hope it's useful.
