### PR TITLE
Fix: runner path issue, handle tmux not running

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -190,11 +190,15 @@ end
 
 class CurrentTmuxSession < TmuxSession
   def initialize
-    session = self.get_session
-    window = self.get_property(:active, :window)
-    pane = self.get_property(:active, :pane)
+    if tmux?
+      session = self.get_session
+      window = self.get_property(:active, :window)
+      pane = self.get_property(:active, :pane)
 
-    super(session, window, pane)
+      super(session, window, pane)
+    else
+      raise "You are not in a tmux session"
+    end
   end
 
   def get_property(match, type)
@@ -205,6 +209,10 @@ class CurrentTmuxSession < TmuxSession
 
   def get_session
     _run("display -p '#S'").strip
+  end
+
+  def tmux?
+    `echo $TMUX` =~ /.+/ ? true : false
   end
 end
 EOF


### PR DESCRIPTION
### Runner path issue

If you set the default-path option for tmux, new panes won't be in the correct directory. To fix this, you cd to vim's working directory when a new pane is created.
### Handle not being in a tmux session

If you run a command outside of tmux (maybe by accident) it explodes with output. To fix, you check the $TMUX environment variable and throw an exception if you aren't in a tmux session.
