### PR TITLE
Add `CloseVimTmuxRunner` command

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -56,6 +56,14 @@ Move into the tmux runner pane created by `RunVimTmuxCommand` and enter copy mod
 map <Leader>ri :InspectVimTmuxRunner<CR>
 ```
 
+### CloseVimTmuxRunner
+Close the tmux runner created by `RunVimTmuxCommand`
+
+```viml
+" Close vim tmux runner opened by RunVimTmuxCommand
+map <Leader>rq :CloseVimTmuxRunner<CR>
+```
+
 ### CloseVimTmuxPanes
 Close all other tmux panes in the current window.
 
@@ -89,6 +97,9 @@ map <Leader>ri :InspectVimTmuxRunner<CR>
 
 " Close all other tmux panes in current window
 map <Leader>rx :CloseVimTmuxPanes<CR>
+
+" Close vim tmux runner opened by RunVimTmuxCommand
+map <Leader>rq :CloseVimTmuxRunner<CR>
 
 " Interrupt any command running in the runner pane
 map <Leader>rs :InterruptVimTmuxRunner<CR>

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -8,6 +8,7 @@ if !has("ruby")
 end
 
 command RunLastVimTmuxCommand :call RunLastVimTmuxCommand()
+command CloseVimTmuxRunner :call CloseVimTmuxRunner()
 command CloseVimTmuxPanes :call CloseVimTmuxPanes()
 command CloseVimTmuxWindows :call CloseVimTmuxWindows()
 command InspectVimTmuxRunner :call InspectVimTmuxRunner()
@@ -48,6 +49,11 @@ function CloseVimTmuxWindows()
   ruby CurrentTmuxSession.new.close_other_panes
   call ClearVimTmuxWindow()
   echoerr "CloseVimTmuxWindows is deprecated, use CloseVimTmuxPanes"
+endfunction
+
+function CloseVimTmuxRunner()
+  ruby CurrentTmuxSession.new.close_runner_pane
+  call ClearVimTmuxWindow()
 endfunction
 
 function CloseVimTmuxPanes()
@@ -167,6 +173,10 @@ class TmuxSession
     reset_shell
     _send_command(command, target(:pane => runner_pane), auto_return)
     _move_up_pane
+  end
+
+  def close_runner_pane
+    _run("kill-pane -t #{target(:pane => runner_pane)}")
   end
 
   def close_other_panes


### PR DESCRIPTION
Closes runner pane only, leaving any other panes in current window intact.

The default CloseVimTmuxPanes is very annoying if you happen to have 4-5 other active panes in current window...
