### PR TITLE
Add function for gracefully degrading commands

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -10,11 +10,12 @@ CONTENTS                                                        *vimux-contents*
     2. Usage ........................... |VimuxUsage|
       2.1 .............................. |VimuxPromptCommand|
       2.2 .............................. |VimuxRunLastCommand|
-      2.3 .............................. |VimuxInspectRunner|
-      2.4 .............................. |VimuxCloseRunner|
-      2.5 .............................. |VimuxClosePanes|
-      2.6 .............................. |VimuxInterruptRunner|
-      2.7 .............................. |VimuxClearRunnerHistory|
+      2.3 .............................. |VimuxRunCommandOrFallback|
+      2.4 .............................. |VimuxInspectRunner|
+      2.5 .............................. |VimuxCloseRunner|
+      2.6 .............................. |VimuxClosePanes|
+      2.7 .............................. |VimuxInterruptRunner|
+      2.8 .............................. |VimuxClearRunnerHistory|
     3. Misc ............................ |VimuxMisc|
       3.1 Example Keybinding............ |VimuxExampleKeybinding|
       3.2 Tslime Replacement............ |VimuxTslimeReplacement|
@@ -62,6 +63,7 @@ process finishes and will see the output in the pane when it's finished.
 Furthermore there are several handy commands all starting with 'Vimux':
   - |VimuxRunCommand|
   - |VimuxRunLastCommand| 
+  - VimuxRunCommandOrFallback
   - |VimuxCloseRunner|
   - |VimuxClosePanes|
   - |VimuxCloseWindows|
@@ -120,6 +122,19 @@ Run the last command executed by `VimuxRunCommand`
 >
  " Run last command executed by VimuxRunCommand
  map <Leader>vl :VimuxRunLastCommand<CR>
+<
+
+------------------------------------------------------------------------------
+                                                   *VimuxRunCommandOrFallback*
+VimuxRunCommandOrFallback~
+
+Runs the specified command in similar fashion to VimuxRunCommand. However, if
+you are not currently operating inside of a tmux session, this command will
+fall back on simple shell execution (using the ! command) to ensure that the
+command gets run.
+>
+ " Execute `git status` in a vimux window if we can, otherwise run it using !
+ map <Leader>gs :call VimuxRunCommandOrFallback("git status")<CR>
 <
 
 ------------------------------------------------------------------------------

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -85,6 +85,17 @@ function RunLastVimTmuxCommand()
   call VimuxRunLastCommand()
 endfunction
 
+function VimuxRunCommandOrFallback(command, ...)
+  if VimuxInTmux()
+    let l:autoreturn = 1
+    if exists("a:1")
+      let l:autoreturn = a:1
+    endif
+    call VimuxRunCommand(a:command, l:autoreturn)
+  else
+    exec "!" . a:command
+  endif
+endfunction
 
 function VimuxClearWindow()
   if exists("g:_VimTmuxRunnerPane")
@@ -163,9 +174,12 @@ function PromptVimTmuxCommand()
   call VimuxPromptCommand()
 endfunction
 
-
 function VimuxClearRunnerHistory()
   ruby CurrentTmuxSession.new.clear_runner_history
+endfunction
+
+function VimuxInTmux()
+  return system("echo $TMUX") =~ "\\w\\+"
 endfunction
 
 ruby << EOF


### PR DESCRIPTION
I had a feature request for vimux and thought I would just put together a pull request rather than open up an issue. Hope you don't mind, @benmills.

Since I started using vimux, I've been gradually replacing a lot of my old keybindings that interact with the shell environment with calls to RunVimuxCommand. Unfortunately, I'm not always _in_ a tmux session, so I've found myself often writing custom functions that look like:

```
function TMDoStuff()
  if InTmux()
    VimuxRunCommand("command")
  else
    exec "!command"
  endif
endfunction
```

It seems reasonable to me that this is functionality Vimux might provide by default, so I added a new function that generalizes this pattern: `VimuxRunCommandOrFallback`. The above function can now be handled with a single mapping:

`map <C-c> :call VimuxRunCommandOrFallback("command")`

...which will execute `command` in vimux if possible, and will otherwise execute `command` using vim's normal shell interaction (the `!` command).

Hopefully this is useful.

Oh, and in any event, thanks a lot for writing/maintaining this plugin. It's a fantastic aide to my development process :)
