### PR TITLE
Fixed for VimuxRunPrompt not working with default

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -154,10 +154,9 @@ endfunction
 
 
 function VimuxPromptCommand()
+  let l:command = input("Command? ")
   if exists("g:VimuxPromptString")
     let l:command = input(g:VimuxPromptString)
-  elseif
-    let l:command = input("Command? ")
   endif
   call VimuxRunCommand(l:command)
 endfunction


### PR DESCRIPTION
Moved initialization of the default outside the if statement.
Otherwise i get a 'Undefined variable l:command'  when using
calling VimuxRunPrompt.

/brian
