### PR TITLE
Improve close_runner_pane

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -293,7 +293,7 @@ class TmuxSession
   end
 
   def close_runner_pane
-    _run("kill-pane -t #{target(:pane => runner_pane)}")
+    _run("kill-pane -t #{target(:pane => runner_pane)}") unless @runner_pane.nil?
   end
 
   def close_other_panes


### PR DESCRIPTION
Do not execute `tmux kill-pane` when a runner pane is not available.

Avoids UI glitches in tmux when :VimuxCloseRunner is auto-called before exiting
Vim.
