### PR TITLE
Allow backticks

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -38,7 +38,7 @@ function VimuxRunCommand(command, ...)
     let l:autoreturn = a:1
   endif
 
-  let s:_VimTmuxCmd = a:command
+  let s:_VimTmuxCmd = substitute(a:command, '`', '\\`', 'g')
   let s:_VimTmuxCmdAutoreturn = l:autoreturn
 
   if l:autoreturn == 1
@@ -57,7 +57,7 @@ function RunVimTmuxCommand(command, ...)
     let l:autoreturn = a:1
   endif
 
-  let s:_VimTmuxCmd = a:command
+  let s:_VimTmuxCmd = substitute(a:command, '`', '\\`', 'g')
   let s:_VimTmuxCmdAutoreturn = l:autoreturn
 
   if l:autoreturn == 1


### PR DESCRIPTION
sending backticks currently gives an unexpected end of line, since the plugins run command tries to execute the content.

also fixes some nastyness of potentially executing code that should not be executed
