### PR TITLE
Escape a semicolon at the end of input

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -322,7 +322,7 @@ class TmuxSession
   end
 
   def _escape_command(command)
-    command.gsub('"', '\"').gsub('$', '\$')
+    command.gsub('"', '\"').gsub('$', '\$').sub(/;\z/, '\;')
   end
 
   def _run(command)


### PR DESCRIPTION
Avoid tmux treating it as a separator.
