### PR TITLE
Optionally set working directory of created pane to result of g:ProjectRoot()

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -113,6 +113,10 @@ This will either opne a new pane or use the nearest pane and set it as the
 vimux runner pane for the other vimux commands. You can control if this command
 uses the nearest pane or always creates a new one with g:VimuxUseNearestPane
 
+If you have a g:ProjectRoot() function defined, it will call this function and
+set the working directory of newly created pane to the result, otherwise the
+working directory will default to current directory of vim.
+
 ------------------------------------------------------------------------------
                                                             *VimuxPromptCommand*
 VimuxPromptCommand~

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -57,11 +57,18 @@ function! VimuxOpenPane()
   let height = _VimuxOption("g:VimuxHeight", 20)
   let orientation = _VimuxOption("g:VimuxOrientation", "v")
   let nearestIndex = _VimuxNearestPaneIndex()
+  let set_start_directory = ''
+  if exists('*g:ProjectRoot')
+    let project_root = g:ProjectRoot()
+    if project_root != ''
+      let set_start_directory = "-c ".project_root
+    endif
+  endif
 
   if _VimuxOption("g:VimuxUseNearestPane", 1) == 1 && nearestIndex != -1
     let g:VimuxRunnerPaneIndex = nearestIndex
   else
-    call system("tmux split-window -p ".height." -".orientation)
+    call system("tmux split-window ".set_start_directory." -p ".height." -".orientation)
     let g:VimuxRunnerPaneIndex = _VimuxTmuxPaneIndex()
     call system("tmux last-pane")
   endif


### PR DESCRIPTION
Its useful to provide this if vim users have some settings in their .vimrc to automatically change working directory of vim to directory of current file. So for example vim-zeus will run commands in Rails root instead of a sub-directory like `spec/modes` and fails due to can't know how to connect to zeus server.
