### PR TITLE
Fixing out of range error

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -121,9 +121,9 @@ endfunction
 function! _VimuxNearestPaneIndex()
   let panes = split(system("tmux list-panes"), "\n")
 
-  for i in panes
-    if match(panes[i], "(active)") == -1
-      return split(panes[i], ":")[0]
+  for pane in panes
+    if match(pane, "(active)") == -1
+      return split(pane, ":")[0]
     endif
   endfor
 


### PR DESCRIPTION
Fix the following error. This fixes #72.

```
E684: list index out of range: 1
E116: Invalid arguments for function match(panes[i], "(active)") == -1
E15: Invalid expression: match(panes[i], "(active)") == -1
```
