### PR TITLE
add VimuxZoomRunner() to zoom the runner pane on Tmux 1.8

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -15,6 +15,7 @@ CONTENTS                                                        *vimux-contents*
       2.5 .............................. |VimuxClosePanes|
       2.6 .............................. |VimuxInterruptRunner|
       2.7 .............................. |VimuxClearRunnerHistory|
+      2.8 .............................. |VimuxZoomRunner|
     3. Misc ............................ |VimuxMisc|
       3.1 Example Keybinding............ |VimuxExampleKeybinding|
       3.2 Tslime Replacement............ |VimuxTslimeReplacement|
@@ -72,6 +73,7 @@ Furthermore there are several handy commands all starting with 'Vimux':
   - |VimuxInterruptRunner|
   - |VimuxPromptCommand|
   - |VimuxClearRunnerHistory|
+  - |VimuxZoomRunner|
 
 ------------------------------------------------------------------------------
                                                                *VimuxRunCommand*
@@ -179,6 +181,18 @@ you enter tmux scroll mode inside the runner pane.
  <Leader>vc :VimuxClearRunnerHistory<CR>
 <
 
+------------------------------------------------------------------------------
+                                                          *VimuxZoomRunner*
+VimuxZoomRunner~
+
+Zoom the runner pane. Once its zoomed, you will need
+to use tmux "<bind-key> z" to restore the runner pane.
+Zoom requires tmux version >= 1.8
+>
+
+ " Zoom the tmux runner page
+ <Leader>vz :VimuxZoomRunner<CR>
+<
 
 ==============================================================================
 MISC (3)                                                             *VimuxMisc*
@@ -193,18 +207,21 @@ Full Keybind Example~
 
  " Prompt for a command to run
  map <Leader>vp :VimuxPromptCommand<CR>
- 
+
  " Run last command executed by VimuxRunCommand
  map <Leader>vl :VimuxRunLastCommand<CR>
- 
+
  " Inspect runner pane
  map <Leader>vi :VimuxInspectRunner<CR>
- 
+
  " Close vim tmux runner opened by VimuxRunCommand
  map <Leader>vq :VimuxCloseRunner<CR>
- 
+
  " Interrupt any command running in the runner pane
  map <Leader>vx :VimuxInterruptRunner<CR>
+
+ " Zoom the runner pane (use <bind-key> z to restore runner pane)
+ map <Leader>vz :call VimuxZoomRunner()<CR>
 >
 
 ------------------------------------------------------------------------------

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -5,6 +5,7 @@ let g:loaded_vimux = 1
 
 command VimuxRunLastCommand :call VimuxRunLastCommand()
 command VimuxCloseRunner :call VimuxCloseRunner()
+command VimuxZoomRunner :call VimuxZoomRunner()
 command VimuxInspectRunner :call VimuxInspectRunner()
 command VimuxScrollUpInspect :call VimuxScrollUpInspect()
 command VimuxScrollDownInspect :call VimuxScrollDownInspect()
@@ -70,6 +71,13 @@ endfunction
 function! VimuxCloseRunner()
   if exists("g:VimuxRunnerPaneIndex")
     call system("tmux kill-pane -t ".g:VimuxRunnerPaneIndex)
+    unlet g:VimuxRunnerPaneIndex
+  endif
+endfunction
+
+function! VimuxZoomRunner()
+  if exists("g:VimuxRunnerPaneIndex")
+    call system("tmux resize-pane -Z -t ".g:VimuxRunnerPaneIndex)
     unlet g:VimuxRunnerPaneIndex
   endif
 endfunction


### PR DESCRIPTION
added a command to zoom the runner pane to full screen to see more output. You have to run the tmux
command <bind-key> z to reduce the window size. Requires Tmux 1.8
