### PR TITLE
Ability to change runner type

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -54,14 +54,19 @@ function! VimuxSendKeys(keys)
 endfunction
 
 function! VimuxOpenRunner()
-  let height = _VimuxOption("g:VimuxHeight", 20)
-  let orientation = _VimuxOption("g:VimuxOrientation", "v")
   let nearestIndex = _VimuxNearestIndex()
 
   if _VimuxOption("g:VimuxUseNearest", 1) == 1 && nearestIndex != -1
     let g:VimuxRunnerIndex = nearestIndex
   else
-    call system("tmux split-window -p ".height." -".orientation)
+    if _VimuxRunnerType() == "pane"
+      let height = _VimuxOption("g:VimuxHeight", 20)
+      let orientation = _VimuxOption("g:VimuxOrientation", "v")
+      call system("tmux split-window -p ".height." -".orientation)
+    elseif _VimuxRunnerType() == "window"
+      call system("tmux new-window")
+    endif
+
     let g:VimuxRunnerIndex = _VimuxTmuxIndex()
     call system("tmux last-"._VimuxRunnerType())
   endif
@@ -111,7 +116,15 @@ function! _VimuxTmuxSession()
 endfunction
 
 function! _VimuxTmuxIndex()
-  return _VimuxTmuxProperty("P")
+  if _VimuxRunnerType == "pane"
+    return _VimuxTmuxPaneIndex()
+  else
+    return _VimuxTmuxWindowIndex()
+  end
+endfunction
+
+function! _VimuxTmuxPaneIndex()
+    return _VimuxTmuxProperty("P")
 endfunction
 
 function! _VimuxTmuxWindowIndex()


### PR DESCRIPTION
Wanted to use windows instead of panes.

`let g:VimuxRunnerType="window"`

changes `g:VimuxUseNearestPane` to `g:VimuxUseNearest`
