### PR TITLE
Fix condition in _VimuxTmuxIndex()

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -124,7 +124,7 @@ function! _VimuxTmuxSession()
 endfunction
 
 function! _VimuxTmuxIndex()
-  if _VimuxRunnerType == "pane"
+  if _VimuxRunnerType() == "pane"
     return _VimuxTmuxPaneIndex()
   else
     return _VimuxTmuxWindowIndex()


### PR DESCRIPTION
This ensure that we call `_VimuxRunnerType()` instead of
`_VimuxRunnerType`.
