### PR TITLE
Identify a pane by its window and its pane index

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -120,7 +120,7 @@ function! VimuxPromptCommand()
 endfunction
 
 function! _VimuxTmuxSession()
-  return _VimuxTmuxProperty("S")
+  return _VimuxTmuxProperty("#S")
 endfunction
 
 function! _VimuxTmuxIndex()
@@ -132,11 +132,11 @@ function! _VimuxTmuxIndex()
 endfunction
 
 function! _VimuxTmuxPaneIndex()
-    return _VimuxTmuxProperty("P")
+  return _VimuxTmuxProperty("#I.#P")
 endfunction
 
 function! _VimuxTmuxWindowIndex()
-  return _VimuxTmuxProperty("I")
+  return _VimuxTmuxProperty("#I")
 endfunction
 
 function! _VimuxNearestIndex()
@@ -164,9 +164,9 @@ function! _VimuxOption(option, default)
 endfunction
 
 function! _VimuxTmuxProperty(property)
-    return substitute(system("tmux display -p '#".a:property."'"), '\n$', '', '')
+    return substitute(system("tmux display -p '".a:property."'"), '\n$', '', '')
 endfunction
 
 function! _VimuxHasRunner(index)
-  return match(system("tmux list-"._VimuxRunnerType()."s"), a:index.":")
+  return match(system("tmux list-"._VimuxRunnerType()."s -a"), a:index.":")
 endfunction


### PR DESCRIPTION
By identifying a pane by both its window and pane index, `VimuxCloseRunner()` will always close the correct pane, even in case `VimuxCloseRunner()` is called from a Vim instance in a different window than the current window.

This fixes closing a pane in the current window from a `VimuxCloseRunner()` call executed in a Vim instance in a different window. I'm sending Vim commands to a Vim server from a Vimux runner, that is the reason why I encounter this issue.
