### PR TITLE
Escape "\" and "$"

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -43,7 +43,7 @@ function! VimuxRunCommand(command, ...)
 endfunction
 
 function! VimuxSendText(text)
-  call VimuxSendKeys('"'.escape(a:text, '"').'"')
+  call VimuxSendKeys('"'.escape(a:text, '"''\''$').'"')
 endfunction
 
 function! VimuxSendKeys(keys)


### PR DESCRIPTION
To send "$" and "\" to a repl session. (E.g. R uses "$" as an indexer.)

PS: This is my first pull request. If I missed an important point about how to do this (though I tried to inform myself thoroughly) I’m sorry.
