### PR TITLE
Stop Vimux from spewing garbage text

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -159,7 +159,7 @@ function! _VimuxNearestIndex()
   let views = split(system("tmux list-"._VimuxRunnerType()."s"), "\n")
 
   for view in views
-    if match(view, "(active)") != -1
+    if match(view, "(active)") == -1
       return split(view, ":")[0]
     endif
   endfor


### PR DESCRIPTION
It seems this was unnecessarily changed in cf6b8c08dbf3, and I don't know if this is the best way to report this, but... it breaks Vimux in its entirety for me. This fixes it.
