### PR TITLE
Send more keys with VimuxSendKeys

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -44,12 +44,25 @@ function! VimuxRunCommand(command, ...)
 endfunction
 
 function! VimuxSendText(text)
-  call VimuxSendKeys('"'.escape(a:text, '"').'"')
+  " Escape double quotes "
+  "call VimuxSendKeys('"'.escape(a:text, '"').'"')
+  " Don't escape, just send it along.
+  call VimuxSendKeys(a:text)
 endfunction
 
 function! VimuxSendKeys(keys)
   if exists("g:VimuxRunnerIndex")
-    call system("tmux send-keys -t ".g:VimuxRunnerIndex." ".a:keys)
+    " This is limited to ~30 lines or so, and I want to send more!
+    " call system("tmux send-keys -t ".g:VimuxRunnerIndex." ".a:keys)
+    " HACK: Write to a temporary file.
+    redir! > /tmp/VimuxSendKeys
+    echo a:keys
+    redir END
+    " Load from the temporary file.
+    " Unfortunately, You have to press Enter to get back to editing.
+    call system("tmux load-buffer /tmp/VimuxSendKeys; tmux paste-buffer -t ".g:VimuxRunnerIndex)
+    " This causes vim to hang. :(
+    " call system("tmux load-buffer -; tmux paste-buffer -t ".g:VimuxRunnerIndex, a:keys)
   else
     echo "No vimux runner pane/window. Create one with VimuxOpenRunner"
   endif


### PR DESCRIPTION
This patch addresses issue #44, where @gberenfield says:

> I can't seem to paste in around 30-40 lines of code into my vimux repl.
> Anything less works fine.

I write the selected text to a temporary file, read the file with tmux,
and paste the contents into the appropriate window.

Caveats:
- When sending the text, vim prompts you with a `more` screen in which you
  must press Enter repeatedly to scroll to the end. The text is actually sent
  after you're done mashing the Enter button. I haven't found a way around
  this -- I'm new to Vimscript.
