### PR TITLE
Run VimuxRunCommand as command

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -3,7 +3,7 @@ if exists("g:loaded_vimux") || &cp
 endif
 let g:loaded_vimux = 1
 
-command -nargs=2 VimuxRunCommand :call VimuxRunCommand(<args>)
+command -nargs=* VimuxRunCommand :call VimuxRunCommand(<args>)
 command VimuxRunLastCommand :call VimuxRunLastCommand()
 command VimuxCloseRunner :call VimuxCloseRunner()
 command VimuxZoomRunner :call VimuxZoomRunner()


### PR DESCRIPTION
vimux is a great idea! Minor quirk: I found myself immediately trying to run a command with a vim command:

```
VimuxRunCommand "rm -irf /"
```

The changes in this pull request allow this.

Thanks again for the nifty plugin!
