### PR TITLE
Use IDs instead of indexes to identify the Runner

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -88,7 +88,7 @@ function! VimuxTogglePane()
         call system("tmux join-pane -d -s ".g:VimuxRunnerIndex." -p "._VimuxOption("g:VimuxHeight", 20))
         let g:VimuxRunnerType = "pane"
     elseif _VimuxRunnerType() == "pane"
-		let g:VimuxRunnerIndex=substitute(system("tmux break-pane -d -t ".g:VimuxRunnerIndex." -P -F '#{window_index}'"), "\n", "", "")
+		let g:VimuxRunnerIndex=substitute(system("tmux break-pane -d -t ".g:VimuxRunnerIndex." -P -F '#{window_id}'"), "\n", "", "")
         let g:VimuxRunnerType = "window"
     endif
   endif
@@ -142,26 +142,27 @@ endfunction
 
 function! _VimuxTmuxIndex()
   if _VimuxRunnerType() == "pane"
-    return _VimuxTmuxPaneIndex()
+    return _VimuxTmuxPaneId()
   else
-    return _VimuxTmuxWindowIndex()
+    return _VimuxTmuxWindowId()
   end
 endfunction
 
-function! _VimuxTmuxPaneIndex()
-  return _VimuxTmuxProperty("#I.#P")
+function! _VimuxTmuxPaneId()
+  return _VimuxTmuxProperty("#{pane_id}")
 endfunction
 
-function! _VimuxTmuxWindowIndex()
-  return _VimuxTmuxProperty("#I")
+function! _VimuxTmuxWindowId()
+  return _VimuxTmuxProperty("#{window_id}")
 endfunction
 
 function! _VimuxNearestIndex()
-  let views = split(system("tmux list-"._VimuxRunnerType()."s"), "\n")
+  let t = _VimuxRunnerType()
+  let views = split(system("tmux list-".t."s -F '#{".t."_active}:#{".t."_id}'"), "\n")
 
   for view in views
-    if match(view, "(active)") == -1
-      return split(view, ":")[0]
+    if match(view, "1:") == -1
+      return split(view, ":")[1]
     endif
   endfor
 
@@ -185,5 +186,6 @@ function! _VimuxTmuxProperty(property)
 endfunction
 
 function! _VimuxHasRunner(index)
-  return match(system("tmux list-"._VimuxRunnerType()."s -a"), a:index.":")
+  let t = _VimuxRunnerType()
+  return match(system("tmux list-".t."s -F '#{".t."_id}'"), a:index)
 endfunction


### PR DESCRIPTION
The IDs are guaranteed to be unique and stay constant, no matter what you do to the pane or window.

This diff is based on the idea in #81, by Roberto Agostino Vitillo (@vitillo), but rewritten to:
- apply to the latest version of the source
- use IDs for both windows and panes, not just panes

I have tested panes and windows as runners, both with `VimuxUseNearest` and without it. `VimuxTogglePane()` also works just fine.

This change is incredibly useful because once you have the runner, you can do whatever you want: spawn new panes, move the pane to a different window, join it back, reorder the panes and windows, change layouts, — it does not matter, your runner will remain set.
