### PR TITLE
Check for a predefined command for prompt before executing

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -131,8 +131,9 @@ function! VimuxClearRunnerHistory()
   endif
 endfunction
 
-function! VimuxPromptCommand(command, ...)
-  let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "),a:command)
+function! VimuxPromptCommand(...)
+  let command = a:0 == 1 ? a:1 : ""
+  let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "), command)
   call VimuxRunCommand(l:command)
 endfunction
 


### PR DESCRIPTION
VimuxPromptCommand was accepting 1 or more arguments instead of 0 or more. Vim
will complain about this despite nargs being set.
