### PR TITLE
Tab now autocompletes in the VimuxPromptOption

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -141,7 +141,7 @@ endfunction
 
 function! VimuxPromptCommand(...)
   let command = a:0 == 1 ? a:1 : ""
-  let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "), command)
+  let l:command = input(_VimuxOption("g:VimuxPromptString", "Command? "), command, 'shellcmd')
   call VimuxRunCommand(l:command)
 endfunction
 


### PR DESCRIPTION
This pull request changes the call to the input function in the `:VimuxPromptCommand` option so that pressing tab autocompletes, just as if it was in the terminal.
