### PR TITLE
Update VimuxSlime example to use VimuxRunCommand

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -251,8 +251,7 @@ First, add some helpful mappings.
 
 >
  function! VimuxSlime()
-  call VimuxSendText(@v)
-  call VimuxSendKeys("Enter")
+  call VimuxRunCommand(@v, 0)
  endfunction
 
  " If text is selected, save it in the v buffer and send that buffer it to tmux


### PR DESCRIPTION
I was a little confused by the example in the VimuxTslimeReplacement 
section until I figured out that it was supposed to be calling
VimuxRunCommand, rather than VimuxSendText -> VimuxSendKeys. 
The intended call is referenced in the follow paragraph, where it 
describes passing `0` as a second arg to that call to avoid an 
unwanted extra newline.