### PR TITLE
Allow extra arguments to be passed when opening the runner

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -362,5 +362,17 @@ redefine this if you're using something like tmate.
 
 Default: "tmux"
 
+------------------------------------------------------------------------------
+                                                              *VimuxOpenExtraArgs*
+2.8 g:VimuxOpenExtraArgs~
+
+Allows addtional arguments to be passed to the tmux command that opens the
+runner. Make sure that the arguments specified are valid depending on whether
+you're using panes or windows, and your version of tmux.
+
+  let g:VimuxOpenExtraArgs = "-c #{pane_current_path}"
+
+Default: "tmux"
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -71,7 +71,7 @@ function! VimuxOpenRunner()
   if _VimuxOption("g:VimuxUseNearest", 1) == 1 && nearestIndex != -1
     let g:VimuxRunnerIndex = nearestIndex
   else
-    let extraArguments = _VimuxOption("g:VimuxOpenExtraArgs", " ")
+    let extraArguments = _VimuxOption("g:VimuxOpenExtraArgs", "")
     if _VimuxRunnerType() == "pane"
       let height = _VimuxOption("g:VimuxHeight", 20)
       let orientation = _VimuxOption("g:VimuxOrientation", "v")

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -5,6 +5,7 @@ let g:loaded_vimux = 1
 
 command -nargs=* VimuxRunCommand :call VimuxRunCommand(<args>)
 command VimuxRunLastCommand :call VimuxRunLastCommand()
+command VimuxOpenRunner :call VimuxOpenRunner()
 command VimuxCloseRunner :call VimuxCloseRunner()
 command VimuxZoomRunner :call VimuxZoomRunner()
 command VimuxInspectRunner :call VimuxInspectRunner()

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -70,12 +70,13 @@ function! VimuxOpenRunner()
   if _VimuxOption("g:VimuxUseNearest", 1) == 1 && nearestIndex != -1
     let g:VimuxRunnerIndex = nearestIndex
   else
+    let extraArguments = _VimuxOption("g:VimuxOpenExtraArgs", " ")
     if _VimuxRunnerType() == "pane"
       let height = _VimuxOption("g:VimuxHeight", 20)
       let orientation = _VimuxOption("g:VimuxOrientation", "v")
-      call _VimuxTmux("split-window -p ".height." -".orientation)
+      call _VimuxTmux("split-window -p ".height." -".orientation." ".extraArguments)
     elseif _VimuxRunnerType() == "window"
-      call _VimuxTmux("new-window")
+      call _VimuxTmux("new-window ".extraArguments)
     endif
 
     let g:VimuxRunnerIndex = _VimuxTmuxIndex()


### PR DESCRIPTION
One possible use case would be to allow the user to specify which directory the runner will open into. Or perhaps they want to set the window name if using a window runner.