### PR TITLE
Define options once at startup

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -287,7 +287,9 @@ extra return. Thanks to @trptcolin for discovering this issue.
 ==============================================================================
 CONFIGURATION (4)                                           *VimuxConfiguration*
 
-You can configure Vimux like this:
+You can configure Vimux as follows. Note that all occurances of global
+variables `g:Vimux...` may also be set using buffer variables `b:Vimux...` to
+change the behavior of Vimux in just the current buffer.
 
 ------------------------------------------------------------------------------
                                                      *VimuxConfiguration_height*


### PR DESCRIPTION
This also removes a couple of "getter" functions that were being used to look up options and fall back to their defaults.

I'm excited to see that this is starting to be actively maintained again! This is just a refactor suggestion so that the use of options in this plugin follows a more common idiom and such that options are easier to work with. (No need to recall the defaults every time you need to look one up).