### PR TITLE
Disallow chaining VimuxRunCommand and VimuxPromptCommand

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -24,7 +24,7 @@ if !executable(VimuxOption('VimuxTmuxCommand'))
   finish
 endif
 
-command -bar -nargs=* VimuxRunCommand :call VimuxRunCommand(<args>)
+command -nargs=* VimuxRunCommand :call VimuxRunCommand(<args>)
 command -bar VimuxRunLastCommand :call VimuxRunLastCommand()
 command -bar VimuxOpenRunner :call VimuxOpenRunner()
 command -bar VimuxCloseRunner :call VimuxCloseRunner()
@@ -33,7 +33,7 @@ command -bar VimuxInspectRunner :call VimuxInspectRunner()
 command -bar VimuxScrollUpInspect :call VimuxScrollUpInspect()
 command -bar VimuxScrollDownInspect :call VimuxScrollDownInspect()
 command -bar VimuxInterruptRunner :call VimuxInterruptRunner()
-command -bar -nargs=? VimuxPromptCommand :call VimuxPromptCommand(<args>)
+command -nargs=? VimuxPromptCommand :call VimuxPromptCommand(<args>)
 command -bar VimuxClearTerminalScreen :call VimuxClearTerminalScreen()
 command -bar VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 command -bar VimuxTogglePane :call VimuxTogglePane()


### PR DESCRIPTION
Fixes #185

Vim does not allow escaping some characters in commands that can be
chained. In particular bars are disallowed and double quotes begin code
comments. Both of these things are regular features in shell command
strings.

I'm disallowing chaining for the two commands that take shell commands
as arguments so they can be used sensibly again. One solution to allow
this might be to have a ...Bar version of each. It might also be
possible to work around this with `:call` and functions instead of
commands.
