### PR TITLE
Add an option to autoclose the runner

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -416,5 +416,16 @@ possible.
 
 Default: 0
 
+------------------------------------------------------------------------------
+                                                            *VimuxCloseOnExit*
+4.11 g:VimuxCloseOnExit~
+
+Set this option to 1 or v:true to tell vimux to close the runner when you quit
+vim.
+
+  let g:VimuxCloseOnExit = 1
+
+Default: 0
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -94,7 +94,7 @@ vimux from automatically sending a return after the command.
 VimuxSendText~
 
 Send raw text to the runner pane. This command will not open a new pane if one
-does not already exist. You will need to use VimuxOpenRunner to do this. This
+does not already exist. You will need to use |VimuxOpenRunner| to do this. This
 command can be used to interact with REPLs or other interactive terminal
 programs that are not shells.
 
@@ -104,7 +104,7 @@ programs that are not shells.
 VimuxSendKeys~
 
 Send keys to the runner pane. This command will not open a new pane if one
-does not already exist. You will need to use VimuxOpenRunner to do this. You
+does not already exist. You will need to use |VimuxOpenRunner| to do this. You
 can use this command to send keys such as "Enter" or "C-c" to the runner pane.
 
 ------------------------------------------------------------------------------
@@ -113,7 +113,7 @@ VimuxOpenRunner~
 
 This will either open a new pane or use the nearest pane and set it as the
 vimux runner pane for the other vimux commands. You can control if this command
-uses the nearest pane or always creates a new one with g:VimuxUseNearest
+uses the nearest pane or always creates a new one with g:|VimuxUseNearest|
 
 ------------------------------------------------------------------------------
                                                             *VimuxPromptCommand*
@@ -295,9 +295,9 @@ change the behavior of Vimux in just the current buffer.
 4.1 g:VimuxHeight~
 
 The percent of the screen the split pane Vimux will spawn should take up.
-
+>
   let g:VimuxHeight = "40"
-
+<
 Default: "20"
 
 ------------------------------------------------------------------------------
@@ -307,9 +307,9 @@ Default: "20"
 The default orientation of the split tmux pane. This tells tmux to make the
 pane either vertically or horizontally, which is backward from how Vim handles
 creating splits.
-
+>
   let g:VimuxOrientation = "h"
-
+<
 Options:
   "v": vertical
   "h": horizontal
@@ -318,13 +318,13 @@ Default: "v"
 
 ------------------------------------------------------------------------------
                                                 *VimuxConfiguration_use_nearest*
-4.3 g:VimuxUseNearest
+4.3 g:VimuxUseNearest~
 
 Use existing pane or window (not used by vim) if found instead of running
 split-window.
-
+>
   let g:VimuxUseNearest = 1
-
+<
 Default: 1
 
 ------------------------------------------------------------------------------
@@ -333,9 +333,9 @@ Default: 1
 
 The keys sent to the runner pane before running a command. By default it sends
 `q` to make sure the pane is not in scroll-mode and `C-u` to clear the line.
-
+>
   let g:VimuxResetSequence = ""
-
+<
 Default: "q C-u"
 
 ------------------------------------------------------------------------------
@@ -345,9 +345,9 @@ Default: "q C-u"
 The string presented in the vim command line when Vimux is invoked. Be sure
 to put a space at the end of the string to allow for distinction between
 the prompt and your input.
-
+>
   let g:VimuxPromptString = ""
-
+<
 Default: "Command? "
 
 ------------------------------------------------------------------------------
@@ -356,9 +356,9 @@ Default: "Command? "
 
 The type of view object Vimux should use for the runner. For reference, a
 tmux session is a group of windows, and a window is a layout of panes.
-
+>
   let g:VimuxRunnerType = "window"
-
+<
 Options:
   "pane": for panes
   "window": for windows
@@ -367,14 +367,16 @@ Default: "pane"
 
 ------------------------------------------------------------------------------
                                                              *VimuxRunnerName*
-4.7 g:VimuxRunnerName
+4.7 g:VimuxRunnerName~
 
 Setting the name for the runner. Works for panes and windows. This makes the
 VimuxRunner reusable between sessions. Caveat is, all your instances (in the
-same session/window) use the same window. 
+same session/window) use the same window.
 
+Caution: It is probably best not to mix this with |VimuxCloseOnExit|.
+>
   let g:VimuxRunnerName = "vimuxout"
-
+<
 Default: ""
 
 ------------------------------------------------------------------------------
@@ -383,9 +385,9 @@ Default: ""
 
 The command that Vimux runs when it calls out to tmux. It may be useful to
 redefine this if you're using something like tmate.
-
+>
   let g:VimuxTmuxCommand = "tmate"
-
+<
 Default: "tmux"
 
 ------------------------------------------------------------------------------
@@ -395,13 +397,13 @@ Default: "tmux"
 Allows addtional arguments to be passed to the tmux command that opens the
 runner. Make sure that the arguments specified are valid depending on whether
 you're using panes or windows, and your version of tmux.
-
+>
   let g:VimuxOpenExtraArgs = "-c #{pane_current_path}"
-
-Default: "tmux"
+<
+Default: ""
 
 ------------------------------------------------------------------------------
-                                                            VimuxExpandCommand
+                                                            *VimuxExpandCommand*
 4.10 g:VimuxExpandCommand~
 
 Should the command given at the prompt via VimuxPromptCommand be expanded
@@ -411,20 +413,22 @@ Unfortunately expand() only expands % (etc.) if the string starts with that
 character. So the command is split at spaces and then rejoined after
 expansion. With this simple approach things like "%:h/test.xml" are not
 possible.
-
+>
   let g:VimuxExpandCommand = 1
-
+<
 Default: 0
 
 ------------------------------------------------------------------------------
                                                             *VimuxCloseOnExit*
 4.11 g:VimuxCloseOnExit~
 
-Set this option to 1 or v:true to tell vimux to close the runner when you quit
+Set this option to `1` or `v:true` to tell vimux to close the runner when you quit
 vim.
 
+Caution: It is probably best not to mix this with |VimuxRunnerName|.
+>
   let g:VimuxCloseOnExit = 1
-
+<
 Default: 0
 
 ==============================================================================

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -15,6 +15,7 @@ let g:VimuxRunnerType    = get(g:, 'VimuxRunnerType',    'pane')
 let g:VimuxTmuxCommand   = get(g:, 'VimuxTmuxCommand',   'tmux')
 let g:VimuxUseNearest    = get(g:, 'VimuxUseNearest',    v:true)
 let g:VimuxExpandCommand = get(g:, 'VimuxExpandCommand', v:false)
+let g:VimuxCloseOnExit   = get(g:, 'VimuxCloseOnExit',   v:false)
 
 function! VimuxOption(name) abort
   return get(b:, a:name, get(g:, a:name))
@@ -38,6 +39,13 @@ command -nargs=? VimuxPromptCommand :call VimuxPromptCommand(<args>)
 command -bar VimuxClearTerminalScreen :call VimuxClearTerminalScreen()
 command -bar VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 command -bar VimuxTogglePane :call VimuxTogglePane()
+
+if VimuxOption('VimuxCloseOnExit')
+    augroup VimuxAutocloseCommands
+        au!
+        autocmd VimLeave * call VimuxCloseRunner()
+    augroup END
+endif
 
 function! VimuxRunCommandInDir(command, useFile)
   let l:file = ''


### PR DESCRIPTION
I find I usually don't actually want the runner to be left open when I quit vim, so this conveniently allows me to shut both down just by quitting vim, no extra cleanup necessary. It turns out that in the odd case where I _do_ want the runner to continue existing after my vim session, taking a second to open a new runner is sufficient to get this this autocommand to ignore the previous runner. Or I could reset this option.

I've set the default to `v:false` to preserve the existing behaviour as the default.