### PR TITLE
Optionally return up-arrow functionality to VimuxPromptCommand

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -431,5 +431,21 @@ Caution: It is probably best not to mix this with |VimuxRunnerName|.
 <
 Default: 0
 
+------------------------------------------------------------------------------
+                                                            *VimuxCommandShell*
+4.12 g:VimuxCommandShell~
+
+Set this option to `1` or `v:true` to enable shell completion in
+VimuxPromptCommand
+Set this option to `0` or `v:false` to enable vim command editing in
+VimuxPromptCommand
+
+Enabling shell completion blocks the ability to use up-arrow to cycle through
+previously-run commands in VimuxPromptCommand.
+>
+  let g:VimuxCommandShell = 0
+<
+Default: 1
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -16,6 +16,7 @@ let g:VimuxTmuxCommand   = get(g:, 'VimuxTmuxCommand',   'tmux')
 let g:VimuxUseNearest    = get(g:, 'VimuxUseNearest',    v:true)
 let g:VimuxExpandCommand = get(g:, 'VimuxExpandCommand', v:false)
 let g:VimuxCloseOnExit   = get(g:, 'VimuxCloseOnExit',   v:false)
+let g:VimuxCommandShell  = get(g:, 'VimuxCommandShell',   v:true)
 
 function! VimuxOption(name) abort
   return get(b:, a:name, get(g:, a:name))
@@ -175,7 +176,12 @@ endfunction
 
 function! VimuxPromptCommand(...)
   let command = a:0 ==# 1 ? a:1 : ''
-  let l:command = input(VimuxOption('VimuxPromptString'), command, 'shellcmd')
+  if VimuxOption('VimuxCommandShell')
+    let l:cancelreturn = 'shellcmd'
+  else
+    let l:cancelreturn = v:false
+  endif
+  let l:command = input(VimuxOption('VimuxPromptString'), command, l:cancelreturn)
   if VimuxOption('VimuxExpandCommand')
     let l:command = join(map(split(l:command, ' '), 'expand(v:val)'), ' ')
   endif

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -177,11 +177,10 @@ endfunction
 function! VimuxPromptCommand(...)
   let command = a:0 ==# 1 ? a:1 : ''
   if VimuxOption('VimuxCommandShell')
-    let l:cancelreturn = 'shellcmd'
+    let l:command = input(VimuxOption('VimuxPromptString'), command, 'shellcmd')
   else
-    let l:cancelreturn = v:false
+    let l:command = input(VimuxOption('VimuxPromptString'), command)
   endif
-  let l:command = input(VimuxOption('VimuxPromptString'), command, l:cancelreturn)
   if VimuxOption('VimuxExpandCommand')
     let l:command = join(map(split(l:command, ' '), 'expand(v:val)'), ' ')
   endif


### PR DESCRIPTION
#188 Having whatever 'shellcmd' does makes Vimux unusable for me. I don't know what shellcmd is doing here and I can't see any documentation on why it was added, but I'm guessing I wasn't using it before so I would like the option to have the old behaviour back. I guess this means you lose autocomplete or something, which I never had, so I can live without that.