### PR TITLE
fix VimuxTogglePane

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -133,7 +133,6 @@ function! VimuxTogglePane()
   endif
 endfunction
 
-
 function! VimuxZoomRunner()
   if exists('g:VimuxRunnerIndex')
     if VimuxOption('VimuxRunnerType') ==# 'pane'

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -122,14 +122,17 @@ endfunction
 function! VimuxTogglePane()
   if exists('g:VimuxRunnerIndex')
     if VimuxOption('VimuxRunnerType') ==# 'window'
-      call VimuxTmux('join-pane -d -s '.g:VimuxRunnerIndex.' -p '.VimuxOption('VimuxHeight'))
-      let VimuxOption('VimuxRunnerType') = 'pane'
+      call VimuxTmux('join-pane -s '.g:VimuxRunnerIndex.' -p '.VimuxOption('VimuxHeight'))
+      let g:VimuxRunnerType = 'pane'
+      let g:VimuxRunnerIndex = s:tmuxIndex()
+      call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
     elseif VimuxOption('VimuxRunnerType') ==# 'pane'
-      let g:VimuxRunnerIndex=substitute(VimuxTmux('break-pane -d -t '.g:VimuxRunnerIndex." -P -F '#{window_id}'"), '\n', '', '')
-      let VimuxOption('VimuxRunnerType') = 'window'
+      let g:VimuxRunnerIndex=substitute(VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"), '\n', '', '')
+      let g:VimuxRunnerType = 'window'
     endif
   endif
 endfunction
+
 
 function! VimuxZoomRunner()
   if exists('g:VimuxRunnerIndex')


### PR DESCRIPTION
Changed join-pane so it focuses on the new pane, grabs the index, then changes focus back to the last window (identical to the method in VimuxOpenRunner)
Fixed setting of g:VimuxRunnerType as old method gave syntax errors.
Also replaced -t flag in break-pane with -s, as we are focusing on the runner as the source pane.

VimuxTogglePane should work as expected now.