### PR TITLE
Use <q-args> instead of <args>

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -125,7 +125,11 @@ command which can be edited in the prompt.
 >
  " Prompt for a command to run map
  map <Leader>vp :VimuxPromptCommand<CR>
- map <Leader>vm :VimuxPromptCommand("make ")<CR>
+
+ " Prefill the command filed with the string "make ".
+ " These maps are equivalent.
+ map <Leader>vm :VimuxPromptCommand make <CR>
+ map <Leader>vm :call VimuxPromptCommand("make ")<CR>
 <
 
 ------------------------------------------------------------------------------

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -81,7 +81,6 @@ function! s:trimQuotes(command)
     let l:end = strgetchar(a:command, length-1)
     if l:start == l:end && index(['"', "'"], nr2char(l:start)) >= 0
       call s:deprecationWarning('No longer necessary to wrap command string in quotes.')
-      echohl None
       return eval(a:command)
     endif
   endif

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -27,7 +27,7 @@ if !executable(VimuxOption('VimuxTmuxCommand'))
   finish
 endif
 
-command -nargs=* VimuxRunCommand :call VimuxRunCommand(<q-args>)
+command -nargs=* VimuxRunCommand :call VimuxRunCommand(s:trimQuotes(<q-args>))
 command -bar VimuxRunLastCommand :call VimuxRunLastCommand()
 command -bar VimuxOpenRunner :call VimuxOpenRunner()
 command -bar VimuxCloseRunner :call VimuxCloseRunner()
@@ -36,7 +36,7 @@ command -bar VimuxInspectRunner :call VimuxInspectRunner()
 command -bar VimuxScrollUpInspect :call VimuxScrollUpInspect()
 command -bar VimuxScrollDownInspect :call VimuxScrollDownInspect()
 command -bar VimuxInterruptRunner :call VimuxInterruptRunner()
-command -nargs=? VimuxPromptCommand :call VimuxPromptCommand(<q-args>)
+command -nargs=? VimuxPromptCommand :call VimuxPromptCommand(s:trimQuotes(<q-args>))
 command -bar VimuxClearTerminalScreen :call VimuxClearTerminalScreen()
 command -bar VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 command -bar VimuxTogglePane :call VimuxTogglePane()
@@ -89,7 +89,6 @@ function! s:trimQuotes(command)
 endfunction
 
 function! VimuxRunCommand(command, ...)
-  let trimmed_command = s:trimQuotes(a:command)
   if !exists('g:VimuxRunnerIndex') || s:hasRunner(g:VimuxRunnerIndex) ==# -1
     call VimuxOpenRunner()
   endif
@@ -98,9 +97,9 @@ function! VimuxRunCommand(command, ...)
     let l:autoreturn = a:1
   endif
   let resetSequence = VimuxOption('VimuxResetSequence')
-  let g:VimuxLastCommand = trimmed_command
+  let g:VimuxLastCommand = a:command
   call VimuxSendKeys(resetSequence)
-  call VimuxSendText(trimmed_command)
+  call VimuxSendText(a:command)
   if l:autoreturn ==# 1
     call VimuxSendKeys('Enter')
   endif
@@ -202,7 +201,7 @@ function! VimuxClearRunnerHistory()
 endfunction
 
 function! VimuxPromptCommand(...)
-  let command = s:trimQuotes(a:0 ==# 1 ? a:1 : '')
+  let command = a:0 ==# 1 ? a:1 : ''
   if VimuxOption('VimuxCommandShell')
     let l:command = input(VimuxOption('VimuxPromptString'), command, 'shellcmd')
   else


### PR DESCRIPTION
This allows calling commands like this:
  `VimuxRunCommand echo Value in '$HOME': $HOME`
Note that no quotes are needed around the command string!
Wrapping the command in quotation characters is still supported though, but with a deprecation warning message.