### PR TITLE
Allow resetting the VimuxCloseOnExit option

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -41,12 +41,10 @@ command -bar VimuxClearTerminalScreen :call VimuxClearTerminalScreen()
 command -bar VimuxClearRunnerHistory :call VimuxClearRunnerHistory()
 command -bar VimuxTogglePane :call VimuxTogglePane()
 
-if VimuxOption('VimuxCloseOnExit')
-    augroup VimuxAutocloseCommands
-        au!
-        autocmd VimLeave * call VimuxCloseRunner()
-    augroup END
-endif
+augroup VimuxAutocmds
+  au!
+  autocmd VimLeave * call s:autoclose()
+augroup END
 
 function! VimuxRunCommandInDir(command, useFile) abort
   let l:file = ''
@@ -269,4 +267,10 @@ endfunction
 function! s:hasRunner(index) abort
   let t = VimuxOption('VimuxRunnerType')
   return match(VimuxTmux('list-'.t."s -F '#{".t."_id}'"), a:index)
+endfunction
+
+function! s:autoclose() abort
+  if VimuxOption('VimuxCloseOnExit')
+    call VimuxCloseRunner()
+  endif
 endfunction


### PR DESCRIPTION
This was an oversight on my part. Anyone using the autoclose option would be unable to prevent the runner from closing when vim exits by simply doing `:let g:VimuxCloseOnExit = v:false`, since the option was only considered when the plugin script is sourced, so the value when vim closes was ignored. This PR remedies that situation.