### PR TITLE
Abort with an error if run outside tmux session

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -193,7 +193,11 @@ function! VimuxTmux(arguments) abort
   if VimuxOption('VimuxDebug')
     echom VimuxOption('VimuxTmuxCommand').' '.a:arguments
   endif
-  return system(VimuxOption('VimuxTmuxCommand').' '.a:arguments)
+  if has_key(environ(), 'TMUX')
+    return system(VimuxOption('VimuxTmuxCommand').' '.a:arguments)
+  else
+    throw 'Aborting, because not inside tmux session.'
+  endif
 endfunction
 
 function! s:tmuxSession() abort


### PR DESCRIPTION
Otherwise, the command sent will run in a different and likely unexpected tmux session.

Fix #203 