### PR TITLE
Support tmux's target-pane and target-window syntax for finding an existing runner

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -447,5 +447,27 @@ previously-run commands in VimuxPromptCommand.
 <
 Default: 1
 
+------------------------------------------------------------------------------
+                                                            *VimuxRunnerQuery*
+4.13 g:VimuxRunnerQuery~
+
+Set this option to define a query to use for looking up an existing runner
+pane or window when initiating Vimux. Uses the tmux syntax for the target-pane
+and target-window command arguments. (See the man page for tmux). It must be a
+dictionary containing up to two keys, "pane" and "window", defining the query
+to use for the respective runner types.
+
+If no key exists for the current runner type, the search for an existing
+runner falls back to the `VimuxUseNearest` option (and the related
+`VimuxRunnerName`). If that option is false or either command fails, a new
+runner is created instead, positioned according to `VimuxOrientation`.
+>
+  let g:VimuxRunnerQuery = {
+            \ 'pane': '{down-of}',
+            \ 'window': 'vimux',
+            \}
+<
+Default: {}
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -231,23 +231,20 @@ endfunction
 " @return a string of the form '%4', the ID of the pane or window to use,
 "   or '' if no nearest pane or window is found.
 function! s:existingRunnerId() abort
-  let query = VimuxOption('VimuxRunnerQuery')
+  let runnerType = VimuxOption('VimuxRunnerType')
+  let query = get(VimuxOption('VimuxRunnerQuery'), runnerType, '')
   if empty(query)
     if !empty(VimuxOption('VimuxUseNearest'))
       return s:nearestRunnerId()
     endif
   endif
-  let runnerType = VimuxOption('VimuxRunnerType')
-  let query = get(query, runnerType, '')
-  if query !=# ''
-    " Try finding the runner using the provided query
-    let message = VimuxTmux('select-'.runnerType.' -t '.query.'')
-    if message ==# ''
-      " Success!
-      let runnerId = s:tmuxIndex()
-      call VimuxTmux('last-'.runnerType)
-      return runnerId
-    endif
+  " Try finding the runner using the provided query
+  let message = VimuxTmux('select-'.runnerType.' -t '.query.'')
+  if message ==# ''
+    " Success!
+    let runnerId = s:tmuxIndex()
+    call VimuxTmux('last-'.runnerType)
+    return runnerId
   endif
   return ''
 endfunction

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -92,9 +92,9 @@ function! VimuxSendKeys(keys) abort
 endfunction
 
 function! VimuxOpenRunner() abort
-  let nearestIndex = s:nearestIndex()
-  if VimuxOption('VimuxUseNearest') ==# 1 && nearestIndex != -1
-    let g:VimuxRunnerIndex = nearestIndex
+  let existingId = s:existingRunnerId()
+  if VimuxOption('VimuxUseNearest') ==# 1 && existingId !=# ''
+    let g:VimuxRunnerIndex = existingId
   else
     let extraArguments = VimuxOption('VimuxOpenExtraArgs')
     if VimuxOption('VimuxRunnerType') ==# 'pane'
@@ -222,16 +222,21 @@ function! s:vimuxPaneOptions() abort
     return '-p '.height.' -'.orientation
 endfunction
 
-function! s:nearestIndex() abort
+""
+" @return a string of the form '%4', the ID of the pane or window to use,
+"   or '' if no nearest pane or window is found.
+function! s:existingRunnerId() abort
   let runnerType = VimuxOption('VimuxRunnerType')
   let filter = s:getTargetFilter()
   let views = split(VimuxTmux('list-'.runnerType."s -F '#{".runnerType.'_active}:#{'.runnerType."_id}'".filter), '\n')
+  " '1:' is the current active pane (the one with vim).
+  " Find the first non-active pane.
   for view in views
     if match(view, '1:') ==# -1
       return split(view, ':')[1]
     endif
   endfor
-  return -1
+  return ''
 endfunction
 
 function! s:getTargetFilter() abort

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -123,7 +123,12 @@ function! VimuxTogglePane() abort
       let g:VimuxRunnerIndex = s:tmuxIndex()
       call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
     elseif VimuxOption('VimuxRunnerType') ==# 'pane'
-      let g:VimuxRunnerIndex=substitute(VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"), '\n', '', '')
+      let g:VimuxRunnerIndex=substitute(
+                  \ VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"),
+                  \ '\n',
+                  \ '',
+                  \ ''
+                  \)
       let g:VimuxRunnerType = 'window'
     endif
   endif
@@ -228,7 +233,12 @@ endfunction
 function! s:existingRunnerId() abort
   let runnerType = VimuxOption('VimuxRunnerType')
   let filter = s:getTargetFilter()
-  let views = split(VimuxTmux('list-'.runnerType."s -F '#{".runnerType.'_active}:#{'.runnerType."_id}'".filter), '\n')
+  let views = split(
+              \ VimuxTmux(
+              \     'list-'.runnerType.'s'
+              \     ." -F '#{".runnerType.'_active}:#{'.runnerType."_id}'"
+              \     .filter),
+              \ '\n')
   " '1:' is the current active pane (the one with vim).
   " Find the first non-active pane.
   for view in views

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -232,6 +232,19 @@ endfunction
 "   or '' if no nearest pane or window is found.
 function! s:existingRunnerId() abort
   let runnerType = VimuxOption('VimuxRunnerType')
+  let query = get(VimuxOption('VimuxRunnerQuery'), runnerType, '')
+  if query !=# ''
+    " Try finding the runner using the provided query
+    let message = VimuxTmux('select-'.runnerType.' -t '.query.'')
+    if message ==# ''
+      " Success!
+      let runnerId = s:tmuxIndex()
+      call VimuxTmux('last-'.runnerType)
+      return runnerId
+    endif
+  endif
+  " Try finding the runner in the current window/session, optionally using a
+  " name/title filter
   let filter = s:getTargetFilter()
   let views = split(
               \ VimuxTmux(

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -223,9 +223,9 @@ function! s:vimuxPaneOptions() abort
 endfunction
 
 function! s:nearestIndex() abort
-  let t = VimuxOption('VimuxRunnerType')
+  let runnerType = VimuxOption('VimuxRunnerType')
   let filter = s:getTargetFilter()
-  let views = split(VimuxTmux('list-'.t."s -F '#{".t.'_active}:#{'.t."_id}'".filter), '\n')
+  let views = split(VimuxTmux('list-'.runnerType."s -F '#{".runnerType.'_active}:#{'.runnerType."_id}'".filter), '\n')
   for view in views
     if match(view, '1:') ==# -1
       return split(view, ':')[1]
@@ -239,10 +239,10 @@ function! s:getTargetFilter() abort
   if targetName ==# ''
     return ''
   endif
-  let t = VimuxOption('VimuxRunnerType')
-  if t ==# 'window'
+  let runnerType = VimuxOption('VimuxRunnerType')
+  if runnerType ==# 'window'
     return " -f '#{==:#{window_name},".targetName."}'"
-  elseif t ==# 'pane'
+  elseif runnerType ==# 'pane'
     return " -f '#{==:#{pane_title},".targetName."}'"
   endif
 endfunction
@@ -252,10 +252,10 @@ function! s:setRunnerName() abort
   if targetName ==# ''
     return
   endif
-  let t = VimuxOption('VimuxRunnerType')
-  if t ==# 'window'
+  let runnerType = VimuxOption('VimuxRunnerType')
+  if runnerType ==# 'window'
     call VimuxTmux('rename-window '.targetName)
-  elseif t ==# 'pane'
+  elseif runnerType ==# 'pane'
     call VimuxTmux('select-pane -T '.targetName)
   endif
 endfunction
@@ -265,8 +265,8 @@ function! s:tmuxProperty(property) abort
 endfunction
 
 function! s:hasRunner(index) abort
-  let t = VimuxOption('VimuxRunnerType')
-  return match(VimuxTmux('list-'.t."s -F '#{".t."_id}'"), a:index)
+  let runnerType = VimuxOption('VimuxRunnerType')
+  return match(VimuxTmux('list-'.runnerType."s -F '#{".runnerType."_id}'"), a:index)
 endfunction
 
 function! s:autoclose() abort


### PR DESCRIPTION
This is intended to resolve #206 

I figured a new option would be appropriate, instead of shoe-horning this into the VimuxUseNearest/VimuxRunnerName combo. I've given this one precedent since it (mostly) covers the use cases provided by that combo.

I say _mostly_ because it doesn't look like tmux supports querying for a pane's title in the same way you can query for a window or session name, at least not the version I'm currently using (3.2a). So that's one possible case where VimuxRunnerName provides functionality that the new VimuxRunnerQuery doesn't. My read on it though is that the "runner name" was mostly for windows, but perhaps I'm mistaken? In any case, it's still fine to use that option if someone wants to.