### PR TITLE
Hotfix for issue from PR #210

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -235,7 +235,9 @@ function! s:existingRunnerId() abort
   let runnerType = VimuxOption('VimuxRunnerType')
   let query = get(VimuxOption('VimuxRunnerQuery'), runnerType, '')
   if empty(query)
-    if !empty(VimuxOption('VimuxUseNearest'))
+    if empty(VimuxOption('VimuxUseNearest'))
+      return ''
+    else
       return s:nearestRunnerId()
     endif
   endif

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -242,12 +242,17 @@ function! s:existingRunnerId() abort
     endif
   endif
   " Try finding the runner using the provided query
+  let currentId = s:tmuxIndex()
   let message = VimuxTmux('select-'.runnerType.' -t '.query.'')
   if message ==# ''
-    " Success!
+      " A match was found. Make sure it isn't the current vim pane/window
+      " though!
     let runnerId = s:tmuxIndex()
-    call VimuxTmux('last-'.runnerType)
-    return runnerId
+    if runnerId !=# currentId
+        " Success!
+        call VimuxTmux('last-'.runnerType)
+        return runnerId
+    endif
   endif
   return ''
 endfunction


### PR DESCRIPTION
#210 was missing some safety checks. See [this comment](https://github.com/preservim/vimux/pull/210#issuecomment-1249577815). This PR adds guardrails to make sure that:
- If `VimuxUseNearest` and `VimuxRunnerQuery` are both false/empty, we definitely don't try to re-use an existing pane/window.
- If we do use a `VimuxRunnerQuery`, and that query happens to end up selecting the current pane (the one running vim), we won't use it.