### PR TITLE
fix pane height parameters

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -225,7 +225,7 @@ endfunction
 function! s:vimuxPaneOptions() abort
     let height = VimuxOption('VimuxHeight')
     let orientation = VimuxOption('VimuxOrientation')
-    return '-p '.height.' -'.orientation
+    return '-l '.height.'% -'.orientation
 endfunction
 
 ""


### PR DESCRIPTION
The plugin does not work at all for me using:
- neovim: any version
- tmux next-3.4

Without this patch the wrong height parameters are sent to tmux, which means no command works at all as the Runner does not open any pane. 

This patch fixed the plugin for me. 

I don't know if these are breaking changes in tmux so I leave the PR here in case someone needs it.