### PR TITLE
Check for errors in system calls

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -469,5 +469,16 @@ runner is created instead, positioned according to `VimuxOrientation`.
 <
 Default: {}
 
+------------------------------------------------------------------------------
+                                                            *VimuxDebug*
+4.13 g:VimuxDebug~
+
+If you're having trouble with vimux, set this option to get vimux to pass each
+tmux command to |echomsg| before running it.
+>
+  let g:VimuxDebug = v:true
+<
+Default: v:false
+
 ==============================================================================
 vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -192,11 +192,12 @@ function! VimuxPromptCommand(...) abort
 endfunction
 
 function! VimuxTmux(arguments) abort
+  let l:tmuxCommand = VimuxOption('VimuxTmuxCommand').' '.a:arguments
   if VimuxOption('VimuxDebug')
-    echom VimuxOption('VimuxTmuxCommand').' '.a:arguments
+    echom l:tmuxCommand
   endif
   if has_key(environ(), 'TMUX')
-    return system(VimuxOption('VimuxTmuxCommand').' '.a:arguments)
+    return system(l:tmuxCommand)
   else
     throw 'Aborting, because not inside tmux session.'
   endif

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -197,7 +197,11 @@ function! VimuxTmux(arguments) abort
     echom l:tmuxCommand
   endif
   if has_key(environ(), 'TMUX')
-    return system(l:tmuxCommand)
+    let l:output = system(l:tmuxCommand)
+    if v:shell_error
+      throw 'Tmux command failed with message:' . l:output
+    endif
+    return l:output
   else
     throw 'Aborting, because not inside tmux session.'
   endif


### PR DESCRIPTION
# Problem
When `Vimux` fails because it tried to do something that's incompatible with the current tmux version, it fails mysteriously. This is because we don't check whether the system calls to tmux succeeded.

# Solution
Check system calls by checking `v:shell_error`. The variable has been around since at least vim version [7.0001](https://github.com/vim/vim/commit/071d4279d6).

I've also documented the `VimuxDebug` option in the help page.