### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.osFlavor }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Enable Universe package repository
         run: |
           sudo add-apt-repository ${{ matrix.vimVersion == 'stable' && 'universe' || 'ppa:neovim-ppa/unstable' }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,13 +5,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        osFlavor: [ubuntu-20.04, ubuntu-18.04]
         vimFlavor: [neovim, vim]
         vimVersion: [stable, unstable]
         exclude:
           - vimFlavor: vim
             vimVersion: unstable
-    runs-on: ${{ matrix.osFlavor }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -5,7 +5,7 @@ jobs:
     name: vint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: vint
         uses: reviewdog/action-vint@v1
         with:

--- a/.github/workflows/vint.yml
+++ b/.github/workflows/vint.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
       - name: Setup dependencies
         run: pip install vim-vint
       - name: Lint Vimscript


### PR DESCRIPTION
# Problem
The CI workflows are failing or not getting picked up by runners.

## Vint
Failing:
```
Run vint .
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.0/x64/bin/vint", line 5, in <module>
    from vint import main
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/vint/__init__.py", line 1, in <module>
    from vint.bootstrap import (
  File "/opt/hostedtoolcache/Python/3.[12](https://github.com/preservim/vimux/actions/runs/6923608934/job/18831713393?pr=222#step:5:13).0/x64/lib/python3.12/site-packages/vint/bootstrap.py", line 5, in <module>
    from vint.linting.cli import CLI
  File "/opt/hostedtoolcache/Python/3.12.0/x64/lib/python3.12/site-packages/vint/linting/cli.py", line 4, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
Error: Process completed with exit code 1.
```

## Check
Not being picked up:
```
Requested labels: ubuntu-18.04
Job defined at: preservim/vimux/.github/workflows/check.yml@refs/pull/222/merge
Waiting for a runner to pick up this job...
```

# Solution
Let's try updating the actions.