### PR TITLE
Handling Missing 'environ' Function

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -195,7 +195,7 @@ function! VimuxTmux(arguments) abort
   if VimuxOption('VimuxDebug')
     echom VimuxOption('VimuxTmuxCommand').' '.a:arguments
   endif
-  if has_key(environ(), 'TMUX')
+  if exists('*environ') && has_key(environ(), 'TMUX') || $TMUX != ''
     return system(VimuxOption('VimuxTmuxCommand').' '.a:arguments)
   else
     throw 'Aborting, because not inside tmux session.'


### PR DESCRIPTION
Hi!

Thanks a lot for this plugin.
I would suggest to check if `environ` function available to provide more compatibility.
I don't know exactly when this function is missing, but i have experienced that it was missing even if vim was in 'nocp' mode.

Thanks for your time.