### PR TITLE
Fix VimuxOpenRunner not working for versions of tmux < 3.4

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -294,11 +294,12 @@ change the behavior of Vimux in just the current buffer.
                                                      *VimuxConfiguration_height*
 4.1 g:VimuxHeight~
 
-The percent of the screen the split pane Vimux will spawn should take up.
+The part of the screen the split pane Vimux will spawn should take up. This
+option accepts both a number of lines/columns or a percentage.
 >
   let g:VimuxHeight = "40"
 <
-Default: "20"
+Default: "20%"
 
 ------------------------------------------------------------------------------
                                                 *VimuxConfiguration_orientation*

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -5,7 +5,7 @@ let g:loaded_vimux = 1
 
 " Set up all global options with defaults right away, in one place
 let g:VimuxDebug         = get(g:, 'VimuxDebug',         v:false)
-let g:VimuxHeight        = get(g:, 'VimuxHeight',        20)
+let g:VimuxHeight        = get(g:, 'VimuxHeight',        '20%')
 let g:VimuxOpenExtraArgs = get(g:, 'VimuxOpenExtraArgs', '')
 let g:VimuxOrientation   = get(g:, 'VimuxOrientation',   'v')
 let g:VimuxPromptString  = get(g:, 'VimuxPromptString',  'Command? ')
@@ -230,7 +230,7 @@ endfunction
 function! s:vimuxPaneOptions() abort
     let height = VimuxOption('VimuxHeight')
     let orientation = VimuxOption('VimuxOrientation')
-    return '-l '.height.'% -'.orientation
+    return '-l '.height.' -'.orientation
 endfunction
 
 ""


### PR DESCRIPTION
This is a fix for #225  to allow VimuxOpenRunner to work for versions of tmux < 3.1

The breaking change was introduced in #217 and was caused because even though the `-l` flag existed for a long time, it never supported percentage signs until tmux 3.1. Relevant part of their CHANGES
```
* Add support for percentage sizes for resize-pane ("-x 10%"). Also change
  split-window and join-pane -l to accept similar percentages and deprecate the
  -p flag.
```

This is an old tmux version so in my opinion the most logical thing is to support by default the newer tmux syntax. The default for `g:VimuxHeight` is `20%`.
This won't support the old tmux flag `-p` so for older versions you'd only be able to specify the size of the split in columns/lines.