### PR TITLE
Do not fail when the runner pane is closed - open other instead

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -167,13 +167,13 @@ function! VimuxInterruptRunner() abort
 endfunction
 
 function! VimuxClearTerminalScreen() abort
-  if exists('g:VimuxRunnerIndex')
+  if exists('g:VimuxRunnerIndex') && s:hasRunner(g:VimuxRunnerIndex) !=# -1
     call VimuxSendKeys('C-l')
   endif
 endfunction
 
 function! VimuxClearRunnerHistory() abort
-  if exists('g:VimuxRunnerIndex')
+  if exists('g:VimuxRunnerIndex') && s:hasRunner(g:VimuxRunnerIndex) !=# -1
     call VimuxTmux('clear-history -t '.g:VimuxRunnerIndex)
   endif
 endfunction


### PR DESCRIPTION
The removed code was preventing a new pane from being opened again after the old one was closed, in particular when used with the option `vim.g['test#preserve_screen'] = 0`

Not having the code haven't caused any known issue.

(fixes https://github.com/preservim/vimux/issues/229).

