### PR TITLE
Use `copy-mode -q` to leave copy mode before running a command

### DIFF
--- a/doc/vimux.txt
+++ b/doc/vimux.txt
@@ -332,12 +332,17 @@ Default: 1
                                              *VimuxConfiguration_reset_sequence*
 4.4 g:VimuxResetSequence~
 
-The keys sent to the runner pane before running a command. By default it sends
-`q` to make sure the pane is not in scroll-mode and `C-u` to clear the line.
+The keys sent to the runner pane before running a command.
+
+When vimux runs a tmux command, it first makes sure that the runner is not in
+copy mode by running `copy-mode -q` on the runner. This sequence is then sent
+to make sure that the runner is ready to receive input.
+
+The default sends `C-u` to clear the line.
 >
   let g:VimuxResetSequence = ""
 <
-Default: "q C-u"
+Default: "C-u"
 
 ------------------------------------------------------------------------------
                                                              *VimuxPromptString*

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -71,10 +71,20 @@ function! VimuxRunCommand(command, ...) abort
   if exists('a:1')
     let l:autoreturn = a:1
   endif
-  let resetSequence = VimuxOption('VimuxResetSequence')
+  let l:resetSequence = VimuxOption('VimuxResetSequence')
   let g:VimuxLastCommand = a:command
-  call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
-  call VimuxSendKeys(resetSequence)
+
+  try
+    call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
+  catch
+    let l:versionString = s:tmuxProperty('#{version}')
+    if str2float(l:versionString) < 3.2
+        let l:resetSequence = 'q '.l:resetSequence
+    else
+    endif
+  endtry
+  call VimuxSendKeys(l:resetSequence)
+
   call VimuxSendText(a:command)
   if l:autoreturn ==# 1
     call VimuxSendKeys('Enter')

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -9,7 +9,7 @@ let g:VimuxHeight        = get(g:, 'VimuxHeight',        '20%')
 let g:VimuxOpenExtraArgs = get(g:, 'VimuxOpenExtraArgs', '')
 let g:VimuxOrientation   = get(g:, 'VimuxOrientation',   'v')
 let g:VimuxPromptString  = get(g:, 'VimuxPromptString',  'Command? ')
-let g:VimuxResetSequence = get(g:, 'VimuxResetSequence', 'q C-u')
+let g:VimuxResetSequence = get(g:, 'VimuxResetSequence', 'C-u')
 let g:VimuxRunnerName    = get(g:, 'VimuxRunnerName',    '')
 let g:VimuxRunnerType    = get(g:, 'VimuxRunnerType',    'pane')
 let g:VimuxRunnerQuery   = get(g:, 'VimuxRunnerQuery',   {})
@@ -73,6 +73,7 @@ function! VimuxRunCommand(command, ...) abort
   endif
   let resetSequence = VimuxOption('VimuxResetSequence')
   let g:VimuxLastCommand = a:command
+  call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
   call VimuxSendKeys(resetSequence)
   call VimuxSendText(a:command)
   if l:autoreturn ==# 1

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -80,7 +80,6 @@ function! VimuxRunCommand(command, ...) abort
     let l:versionString = s:tmuxProperty('#{version}')
     if str2float(l:versionString) < 3.2
         let l:resetSequence = 'q '.l:resetSequence
-    else
     endif
   endtry
   call VimuxSendKeys(l:resetSequence)


### PR DESCRIPTION
Fixes #230 

Four years ago `tmux` introduced a `-q` flag to `copy-mode`: https://github.com/tmux/tmux/commit/06c3079d66929e0c71575e877098fc533ae5f4a5

Using `copy-mode -q` on the runner instead of relying on the `q` mapping, which could be remapped, should be more reliable.

This updates the default value of `VimuxResetSequence` from `"q C-u"` to simply `"C-u"`.

This will pose problems for users on a `tmux` version older than the introduction of the `-q` flag (before version 3.2a). We could perhaps catch the unknown flag error and try using `q` in those cases.