### PR TITLE
Exit copy-mode when clearing terminal screen

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -71,9 +71,11 @@ function! VimuxRunCommand(command, ...) abort
   if exists('a:1')
     let l:autoreturn = a:1
   endif
+  let l:resetSequence = VimuxOption('VimuxResetSequence')
   let g:VimuxLastCommand = a:command
 
-  call s:reset()
+  call s:exitCopyMode()
+  call VimuxSendKeys(l:resetSequence)
   call VimuxSendText(a:command)
   if l:autoreturn ==# 1
     call VimuxSendKeys('Enter')
@@ -168,7 +170,7 @@ endfunction
 
 function! VimuxClearTerminalScreen() abort
   if exists('g:VimuxRunnerIndex') && s:hasRunner(g:VimuxRunnerIndex) !=# -1
-    call s:reset()
+    call s:exitCopyMode()
     call VimuxSendKeys('C-l')
   endif
 endfunction
@@ -208,18 +210,15 @@ function! VimuxTmux(arguments) abort
   endif
 endfunction
 
-function! s:reset() abort
-  let l:resetSequence = VimuxOption('VimuxResetSequence')
-
+function! s:exitCopyMode() abort
   try
     call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
   catch
     let l:versionString = s:tmuxProperty('#{version}')
     if str2float(l:versionString) < 3.2
-        let l:resetSequence = 'q '.l:resetSequence
+        call VimuxSendKeys('q')
     endif
   endtry
-  call VimuxSendKeys(l:resetSequence)
 endfunction
 
 function! s:tmuxSession() abort

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -71,19 +71,9 @@ function! VimuxRunCommand(command, ...) abort
   if exists('a:1')
     let l:autoreturn = a:1
   endif
-  let l:resetSequence = VimuxOption('VimuxResetSequence')
   let g:VimuxLastCommand = a:command
 
-  try
-    call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
-  catch
-    let l:versionString = s:tmuxProperty('#{version}')
-    if str2float(l:versionString) < 3.2
-        let l:resetSequence = 'q '.l:resetSequence
-    endif
-  endtry
-  call VimuxSendKeys(l:resetSequence)
-
+  call s:reset()
   call VimuxSendText(a:command)
   if l:autoreturn ==# 1
     call VimuxSendKeys('Enter')
@@ -178,6 +168,7 @@ endfunction
 
 function! VimuxClearTerminalScreen() abort
   if exists('g:VimuxRunnerIndex') && s:hasRunner(g:VimuxRunnerIndex) !=# -1
+    call s:reset()
     call VimuxSendKeys('C-l')
   endif
 endfunction
@@ -215,6 +206,20 @@ function! VimuxTmux(arguments) abort
   else
     throw 'Aborting, because not inside tmux session.'
   endif
+endfunction
+
+function! s:reset() abort
+  let l:resetSequence = VimuxOption('VimuxResetSequence')
+
+  try
+    call VimuxTmux('copy-mode -q -t '.g:VimuxRunnerIndex)
+  catch
+    let l:versionString = s:tmuxProperty('#{version}')
+    if str2float(l:versionString) < 3.2
+        let l:resetSequence = 'q '.l:resetSequence
+    endif
+  endtry
+  call VimuxSendKeys(l:resetSequence)
 endfunction
 
 function! s:tmuxSession() abort


### PR DESCRIPTION
Thanks for identifying and fixing the issue with reset in #230! What do you think about invoking reset from `VimuxClearTerminalScreen()` as well? Currently, this command does nothing if the Vim pane is in copy mode.

Ultimately my goal is for vim-test to clear the screen, clear the scrollback buffer, and run the tests. And do all of this regardless of whether the pane was left in copy-mode. 

Right now, vim-test performs the following ([reference](https://github.com/vim-test/vim-test/blob/c090bfd93919888bb0b86e1ab707bc6a3095097f/autoload/test/strategy.vim#L168-L170)):
```vim
    call VimuxClearTerminalScreen()
    call VimuxClearRunnerHistory()
    call VimuxRunCommand(s:command(a:cmd))
```
Since `VimuxRunCommand` is currently the only function that executes the reset sequence, the first two functions (`VimuxClearTerminalScreen` and `VimuxClearRunnerHistory`) do nothing in copy mode. This PR modifies `VimuxClearTerminalScreen` to also execute the reset sequence.

## Other possible solutions

1. A workaround could be to modify vim-test to execute `call VimuxRunCommand("")` before the three lines above, but that approach feels somewhat hacky.
2. Another option could be to create a public `VimuxReset()` function that vim-test could call before executing the lines above. However, I believe VimuxClearTerminalScreen() should ideally handle exiting copy-mode itself.