### PR TITLE
Respect value of g:VimuxRunnerIndex

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -96,7 +96,7 @@ endfunction
 
 function! VimuxOpenRunner() abort
   let existingId = s:existingRunnerId()
-  if existingId !=# ''
+  if !exists('g:VimuxRunnerIndex') && existingId !=# ''
     let g:VimuxRunnerIndex = existingId
   else
     let extraArguments = VimuxOption('VimuxOpenExtraArgs')
@@ -329,7 +329,8 @@ endfunction
 
 function! s:hasRunner(index) abort
   let runnerType = VimuxOption('VimuxRunnerType')
-  return match(VimuxTmux('list-'.runnerType."s -F '#{".runnerType."_id}'"), a:index)
+  let allPanes = runnerType ==# 'pane' ? '-a ' : ''
+  return match(VimuxTmux('list-'.runnerType."s ".allPanes."-F '#{".runnerType."_id}'"), a:index)
 endfunction
 
 function! s:autoclose() abort


### PR DESCRIPTION
Hello!
This PR aims to solve an issue I have that is to select a specific pane to be the runner (any pane across all sessions). I found that the behavior to interact with the runner was slightly inconsistent and didn't quite allow for that.

The best solution I found was to select the runner through the `g:VimuxRunnerIndex`, but without these fixes I wasn't able to use it reliably since `VimuxOpenRunner` would try to get a new runner every time and `VimuxRunCommand` wouldn't recognize the pane unless it's on the current window.

I tested most use cases and it seems to respect the old behavior. Let me know if you agree with this.

PS: This is how I'm using it btw using fzf to pick a pane from the current session (could be adapted to do the same for all sessions)
```vim
function s:VimuxSetPane(line)
  let l:pane_path = substitute(a:line, '[* ]\+\(\d\+\.\d\+\) .*','\1', '')
  let g:VimuxRunnerIndex = substitute(VimuxTmux('display -t '.l:pane_path.' -p "#{pane_id}"'), '\n$', '', '')
endfunction

function s:VimuxPickPaneFzf()
  let opts = {
        \ 'source': 'tmux list-panes -s -F "\033[1;33m#{?pane_active,*, }\033[m:#I.#P:#{pane_current_command}:\033[1;30m#{?#{==:#W,#{pane_current_command}},,(#W)}\033[m:#{?window_linked,\033[1;36m[linked]\033[m,}"|column -ts":" -o" "|while read -r l;do echo "$l";done',
        \ 'sink': function('s:VimuxSetPane'),
        \ 'options': "--prompt 'Vimux Pane> ' --delimiter='[* ]+' --nth=2.. --ansi --no-info --preview='tmux capture-pane -ep -t {2}|cat -s|tail -n $(tput lines)' --preview-window=up,70%"}
  call fzf#run(opts)
endfunction

command! -nargs=0 FZFVimuxPickPane call s:VimuxPickPaneFzf()
```