### PR TITLE
Prevent errors when runner is closed by something other than vimux

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -98,7 +98,7 @@ endfunction
 
 function! VimuxOpenRunner() abort
   if s:hasRunner()
-      return
+    return
   endif
   let existingId = s:existingRunnerId()
   if existingId !=# ''
@@ -132,11 +132,11 @@ function! VimuxTogglePane() abort
       call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
     elseif VimuxOption('VimuxRunnerType') ==# 'pane'
       let g:VimuxRunnerIndex=substitute(
-                  \ VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"),
-                  \ '\n',
-                  \ '',
-                  \ ''
-                  \)
+            \ VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"),
+            \ '\n',
+            \ '',
+            \ ''
+            \)
       let g:VimuxRunnerType = 'window'
     endif
   else
@@ -240,7 +240,7 @@ function! s:exitCopyMode() abort
   catch
     let l:versionString = s:tmuxProperty('#{version}')
     if str2float(l:versionString) < 3.2
-        call s:sendKeys('q')
+      call s:sendKeys('q')
     endif
   endtry
 endfunction
@@ -266,9 +266,9 @@ function! s:tmuxWindowId() abort
 endfunction
 
 function! s:vimuxPaneOptions() abort
-    let height = VimuxOption('VimuxHeight')
-    let orientation = VimuxOption('VimuxOrientation')
-    return '-l '.height.' -'.orientation
+  let height = VimuxOption('VimuxHeight')
+  let orientation = VimuxOption('VimuxOrientation')
+  return '-l '.height.' -'.orientation
 endfunction
 
 ""
@@ -288,13 +288,13 @@ function! s:existingRunnerId() abort
   let currentId = s:tmuxIndex()
   let message = VimuxTmux('select-'.runnerType.' -t '.query.'')
   if message ==# ''
-      " A match was found. Make sure it isn't the current vim pane/window
-      " though!
+    " A match was found. Make sure it isn't the current vim pane/window
+    " though!
     let runnerId = s:tmuxIndex()
     if runnerId !=# currentId
-        " Success!
-        call VimuxTmux('last-'.runnerType)
-        return runnerId
+      " Success!
+      call VimuxTmux('last-'.runnerType)
+      return runnerId
     endif
   endif
   return ''
@@ -306,11 +306,11 @@ function! s:nearestRunnerId() abort
   let runnerType = VimuxOption('VimuxRunnerType')
   let filter = s:getTargetFilter()
   let views = split(
-              \ VimuxTmux(
-              \     'list-'.runnerType.'s'
-              \     ." -F '#{".runnerType.'_active}:#{'.runnerType."_id}'"
-              \     .filter),
-              \ '\n')
+        \ VimuxTmux(
+        \     'list-'.runnerType.'s'
+        \     ." -F '#{".runnerType.'_active}:#{'.runnerType."_id}'"
+        \     .filter),
+        \ '\n')
   " '1:' is the current active pane (the one with vim).
   " Find the first non-active pane.
   for view in views
@@ -353,7 +353,7 @@ endfunction
 
 function! s:hasRunner() abort
   if ! exists('g:VimuxRunnerIndex')
-      return v:false
+    return v:false
   endif
   let l:runnerType = VimuxOption('VimuxRunnerType')
   let l:command = 'list-'.runnerType."s -F '#{".runnerType."_id}'"
@@ -372,7 +372,7 @@ function! s:sendKeys(keys) abort
 endfunction
 
 function! s:sendText(text) abort
-    call s:sendKeys(shellescape(substitute(a:text, '\n$', ' ', '')))
+  call s:sendKeys(shellescape(substitute(a:text, '\n$', ' ', '')))
 endfunction
 
 function! s:echoNoRunner() abort

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -84,7 +84,7 @@ function! VimuxSendText(text) abort
   if s:hasRunner()
     call s:sendText(text)
   else
-    echo 'No vimux runner pane/window. Create one with VimuxOpenRunner'
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -92,7 +92,7 @@ function! VimuxSendKeys(keys) abort
   if s:hasRunner()
     call s:sendKeys(keys)
   else
-    echo 'No vimux runner pane/window. Create one with VimuxOpenRunner'
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -139,6 +139,8 @@ function! VimuxTogglePane() abort
                   \)
       let g:VimuxRunnerType = 'window'
     endif
+  else
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -149,6 +151,8 @@ function! VimuxZoomRunner() abort
     elseif VimuxOption('VimuxRunnerType') ==# 'window'
       call VimuxTmux('select-window -t '.g:VimuxRunnerIndex)
     endif
+  else
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -158,6 +162,7 @@ function! VimuxInspectRunner() abort
     call VimuxTmux('copy-mode')
     return v:true
   endif
+  call s:echoNoRunner()
   return v:false
 endfunction
 
@@ -178,6 +183,8 @@ endfunction
 function! VimuxInterruptRunner() abort
   if s:hasRunner()
     call s:sendKeys('^c')
+  else
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -185,12 +192,16 @@ function! VimuxClearTerminalScreen() abort
   if s:hasRunner()
     call s:exitCopyMode()
     call s:sendKeys('C-l')
+  else
+    call s:echoNoRunner()
   endif
 endfunction
 
 function! VimuxClearRunnerHistory() abort
   if s:hasRunner()
     call VimuxTmux('clear-history -t '.g:VimuxRunnerIndex)
+  else
+    call s:echoNoRunner()
   endif
 endfunction
 
@@ -362,4 +373,8 @@ endfunction
 
 function! s:sendText(text) abort
     call s:sendKeys(shellescape(substitute(a:text, '\n$', ' ', '')))
+endfunction
+
+function! s:echoNoRunner() abort
+  echo 'No vimux runner pane/window. Create one with VimuxOpenRunner'
 endfunction

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -120,7 +120,7 @@ function! VimuxCloseRunner() abort
   if s:hasRunner()
     call VimuxTmux('kill-'.VimuxOption('VimuxRunnerType').' -t '.g:VimuxRunnerIndex)
   endif
-  unlet g:VimuxRunnerIndex
+  unlet! g:VimuxRunnerIndex
 endfunction
 
 function! VimuxTogglePane() abort

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -82,7 +82,7 @@ endfunction
 
 function! VimuxSendText(text) abort
   if s:hasRunner()
-    call s:sendText(text)
+    call s:sendText(a:text)
   else
     call s:echoNoRunner()
   endif
@@ -90,7 +90,7 @@ endfunction
 
 function! VimuxSendKeys(keys) abort
   if s:hasRunner()
-    call s:sendKeys(keys)
+    call s:sendKeys(a:keys)
   else
     call s:echoNoRunner()
   endif

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -116,7 +116,7 @@ function! VimuxCloseRunner() abort
 endfunction
 
 function! VimuxTogglePane() abort
-    if s:hasRunner()
+  if s:hasRunner()
     if VimuxOption('VimuxRunnerType') ==# 'window'
       call VimuxTmux('join-pane -s '.g:VimuxRunnerIndex.' '.s:vimuxPaneOptions())
       let g:VimuxRunnerType = 'pane'

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -352,7 +352,7 @@ function! s:tmuxProperty(property) abort
 endfunction
 
 function! s:hasRunner() abort
-  if ! exists('g:VimuxRunnerIndex')
+  if get(g:, 'VimuxRunnerIndex', '') == ''
     return v:false
   endif
   let l:runnerType = VimuxOption('VimuxRunnerType')

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -153,24 +153,32 @@ function! VimuxZoomRunner() abort
 endfunction
 
 function! VimuxInspectRunner() abort
-  call VimuxTmux('select-'.VimuxOption('VimuxRunnerType').' -t '.g:VimuxRunnerIndex)
-  call VimuxTmux('copy-mode')
+  if s:hasRunner()
+    call VimuxTmux('select-'.VimuxOption('VimuxRunnerType').' -t '.g:VimuxRunnerIndex)
+    call VimuxTmux('copy-mode')
+    return v:true
+  endif
+  return v:false
 endfunction
 
 function! VimuxScrollUpInspect() abort
-  call VimuxInspectRunner()
-  call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
-  call s:sendKeys('C-u')
+  if VimuxInspectRunner()
+    call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
+    call s:sendKeys('C-u')
+  endif
 endfunction
 
 function! VimuxScrollDownInspect() abort
-  call VimuxInspectRunner()
-  call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
-  call s:sendKeys('C-d')
+  if VimuxInspectRunner()
+    call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
+    call s:sendKeys('C-d')
+  endif
 endfunction
 
 function! VimuxInterruptRunner() abort
-  call s:sendKeys('^c')
+  if s:hasRunner()
+    call s:sendKeys('^c')
+  endif
 endfunction
 
 function! VimuxClearTerminalScreen() abort

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -64,9 +64,7 @@ function! VimuxRunLastCommand() abort
 endfunction
 
 function! VimuxRunCommand(command, ...) abort
-  if ! s:hasRunner()
-    call VimuxOpenRunner()
-  endif
+  call VimuxOpenRunner()
   let l:autoreturn = 1
   if exists('a:1')
     let l:autoreturn = a:1


### PR DESCRIPTION
As seen in #236, if the runner was already manually closed when we call `VimuxCloseRunner` we get the following error:
```
Error detected while processing function VimuxCloseRunner[2]..VimuxTmux[8]..function VimuxCloseRunner[2]..VimuxTmux:
line    8:
E605: Exception not caught: Tmux command failed with message:can't find pane: %19^@
Error detected while processing function VimuxCloseRunner:
line    2:
E171: Missing :endif
```
This is an annoyance for people who use `VimuxCloseOnExit`. The error could spread to other commands as well, since the error prevents vimux from unsetting `VimuxRunnerIndex`, leading other commands to believe the runner is still available.

The error can occur in other contexts too, as seen in #229.

We generally only check if the `VimuxRunnerIndex` variable is defined before attempting to interact with the runner. This variable is only unset if vimux closes the runner, so any time anything else loses the runner we will get errors.

We have some options:
1. Always check for the existence of the runner before interacting with it.
2. Add try-catch blocks around each command to check for these errors.

I think for now I'll just enhance the checks we already have to make sure that the runner actually exists, rather than just checking for the index variable's existence.