### PR TITLE
find available pane and prioritize the last active pane

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -310,15 +310,15 @@ function! s:nearestRunnerId() abort
   " name/title filter
   let runnerType = VimuxOption('VimuxRunnerType')
   let filter = s:getTargetFilter()
+  let lastField = runnerType ==# 'pane' ? 'pane_last' : 'window_last_flag'
+  let format = " -F '#{".runnerType."_active}:#{".runnerType."_id}:#{".lastField."}'"
   let views = split(
-        \ VimuxTmux(
-        \     'list-'.runnerType.'s'
-        \     ." -F '#{".runnerType.'_active}:#{'.runnerType."_id}'"
-        \     .filter),
+        \ VimuxTmux('list-'.runnerType.'s' . format . filter),
         \ '\n')
+  let last_runner_first = sort(views, {a, b -> str2nr(split(b, ':')[2]) - str2nr(split(a, ':')[2])})
   " '1:' is the current active pane (the one with vim).
   " Find the first non-active pane.
-  for view in views
+  for view in last_runner_first
     let runnerId = split(view, ':')[1]
     if runnerType ==# 'pane' && !s:isPaneAvailable(runnerId)
       continue


### PR DESCRIPTION
﻿I had nodejs running in one pane and vimux was stubbornly trying to run my commands there, which does nothing useful of course, so i had to come up with a fix.

And another matter: I think it makes sense, if I'm reusing existing panes, to prioritize the one that was active last. But this is very much debatable, of course, I just find it most convenient for my daily use. On the other hand some years back I think vimux was doing just that, if I'm not mistaken, am I? If so, was this behavior disabled then for some reason?