### PR TITLE
Always use pane ID as the runner index

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -111,7 +111,10 @@ function! VimuxOpenRunner() abort
       call VimuxTmux('new-window '.extraArguments)
     endif
     let g:VimuxRunnerIndex = s:tmuxProperty('#{pane_id}')
-    call s:setRunnerName()
+    let targetName = VimuxOption('VimuxRunnerName')
+    if targetName !=# ''
+      call VimuxTmux('select-pane -T '.targetName)
+    endif
     call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
   endif
 endfunction
@@ -283,7 +286,7 @@ function! s:nearestRunnerId() abort
   let views = split(
         \ VimuxTmux(
         \     'list-'.runnerType.'s'
-        \     ." -F '#{".runnerType.'_active}:#{'.runnerType."_id}'"
+        \     ." -F '#{".runnerType.'_active}:#{pane_id}"'
         \     .filter),
         \ '\n')
   " '1:' is the current active pane (the one with vim).
@@ -306,21 +309,6 @@ function! s:getTargetFilter() abort
     return " -f '#{==:#{window_name},".targetName."}'"
   elseif runnerType ==# 'pane'
     return " -f '#{==:#{pane_title},".targetName."}'"
-  endif
-endfunction
-
-function! s:setRunnerName() abort
-  " To be called only while the runner is active, including its window and
-  " session
-  let targetName = VimuxOption('VimuxRunnerName')
-  if targetName ==# ''
-    return
-  endif
-  let runnerType = VimuxOption('VimuxRunnerType')
-  if runnerType ==# 'window'
-    call VimuxTmux('rename-window '.targetName)
-  elseif runnerType ==# 'pane'
-    call VimuxTmux('select-pane -T '.targetName)
   endif
 endfunction
 


### PR DESCRIPTION
With `tmux list-panes -a` we can get all panes across all windows and sessions, allowing us to precisely track our runner no matter where it is. But to do this we need to make `g:VimuxRunnerIndex` always be the pane ID.

This will be a breaking change for any Window runner users who have crafted custom configuration or scripts that modify `g:VimuxRunnerIndex`. I'm going to spend some time thinking about whether there's a way to keep supporting the old functionality, but I'd like to have this code sitting here for comment in the meantime.