### PR TITLE
Improve runner tracking

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -353,6 +353,10 @@ function! s:tmuxProperty(property) abort
   return substitute(VimuxTmux("display -p '".a:property."'"), '\n$', '', '')
 endfunction
 
+function! VimuxHasRunner() abort
+  return s:hasRunner()
+endfunction
+
 function! s:hasRunner() abort
   if get(g:, 'VimuxRunnerIndex', '') ==? ''
     return v:false

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -146,10 +146,10 @@ endfunction
 
 function! VimuxZoomRunner() abort
   if s:hasRunner()
+    call VimuxTmux('switch-client -t '.g:VimuxRunnerIndex)
+    call VimuxTmux('select-window -t '.g:VimuxRunnerIndex)
     if VimuxOption('VimuxRunnerType') ==# 'pane'
       call VimuxTmux('resize-pane -Z -t '.g:VimuxRunnerIndex)
-    elseif VimuxOption('VimuxRunnerType') ==# 'window'
-      call VimuxTmux('select-window -t '.g:VimuxRunnerIndex)
     endif
   else
     call s:echoNoRunner()

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -158,8 +158,10 @@ endfunction
 
 function! VimuxInspectRunner() abort
   if s:hasRunner()
-    call VimuxTmux('select-'.VimuxOption('VimuxRunnerType').' -t '.g:VimuxRunnerIndex)
-    call VimuxTmux('copy-mode')
+    call VimuxTmux('switch-client -t '.g:VimuxRunnerIndex)
+    call VimuxTmux('select-window -t '.g:VimuxRunnerIndex)
+    call VimuxTmux('select-pane -t '.g:VimuxRunnerIndex)
+    call VimuxTmux('copy-mode -t '.g:VimuxRunnerIndex)
     return v:true
   endif
   call s:echoNoRunner()

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -129,7 +129,7 @@ function! VimuxTogglePane() abort
       call VimuxTmux('join-pane -s '.g:VimuxRunnerIndex.' '.s:vimuxPaneOptions())
       let g:VimuxRunnerType = 'pane'
       let g:VimuxRunnerIndex = s:tmuxIndex()
-      call VimuxTmux('last-'.VimuxOption('VimuxRunnerType'))
+      call VimuxTmux('last-pane')
     elseif VimuxOption('VimuxRunnerType') ==# 'pane'
       let g:VimuxRunnerIndex=substitute(
             \ VimuxTmux('break-pane -d -s '.g:VimuxRunnerIndex." -P -F '#{window_id}'"),

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -363,7 +363,7 @@ function! s:hasRunner() abort
   endif
   let runnerType = VimuxOption('VimuxRunnerType')
   let l:command = 'list-'.runnerType."s -a -F '#{".runnerType."_id}'"
-  let l:found = match(VimuxTmux(l:command), g:VimuxRunnerIndex)
+  let l:found = match(VimuxTmux(l:command), g:VimuxRunnerIndex.'\>')
   return l:found != -1
 endfunction
 

--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -362,7 +362,8 @@ function! s:hasRunner() abort
     return v:false
   endif
   let runnerType = VimuxOption('VimuxRunnerType')
-  let l:found = match(VimuxTmux('list-'.runnerType."s -a -F '#{".runnerType."_id}'"), g:VimuxRunnerIndex)
+  let l:command = 'list-'.runnerType."s -a -F '#{".runnerType."_id}'"
+  let l:found = match(VimuxTmux(l:command), g:VimuxRunnerIndex)
   return l:found != -1
 endfunction
 


### PR DESCRIPTION
This PR includes several fixes to improve support for tracking the runner across windows and panes:
- Select the correct session, window, and pane (if applicable) when selecting the runner, not just the correct window/pane.
- Enter copy-mode in the correct window and/or session when inspecting the runnner.
- Specify an end-of-word pattern when checking for runner existence to make sure we match the whole ID.
    - e.g. If the runner index was `'%15'` it previously would have reported that the runner exists even if it doesn't but a pane with index e.g. `'%157'` existed.
- To help with debugging, a `VimuxHasRunner()` function has been added.