### PR TITLE
Support any valid target-pane string in VimuxRunnerIndex

### DIFF
--- a/plugin/vimux.vim
+++ b/plugin/vimux.vim
@@ -361,10 +361,12 @@ function! s:hasRunner() abort
   if get(g:, 'VimuxRunnerIndex', '') ==? ''
     return v:false
   endif
-  let runnerType = VimuxOption('VimuxRunnerType')
-  let l:command = 'list-'.runnerType."s -a -F '#{".runnerType."_id}'"
-  let l:found = match(VimuxTmux(l:command), g:VimuxRunnerIndex.'\>')
-  return l:found != -1
+  try
+    call VimuxTmux('send-keys -t '.g:VimuxRunnerIndex)
+    return v:true
+  catch
+    return v:false
+  endtry
 endfunction
 
 function! s:autoclose() abort


### PR DESCRIPTION
This change makes `s:hasRunner()` effectively query tmux directly for whether the runner exists.  This works for:
- Any form of `target-pane` as described in `man tmux`, e.g.:
  - Local pane index e.g. `0`, `1`, `2`, etc.
  - Pane ID e.g. `%1`, `%28`, etc.
- Any form of `target-window` as described in `man tmux`, when local pane 0 will be used, e.g.:
  - Window ID e.g. `@1`, `@7`
  - `window_index.pane_index` e.g. `:3.2`

The implementation calls `tmux send-keys -t <target_pane>` with no keys, so tmux's exit code determines whether the pane is found but no keys are actually sent to the pane.

I tend to use a local pane index or sometimes a `window.pane` index, which was broken recently when I updated (I think by 383d711).